### PR TITLE
Fix comment end bug

### DIFF
--- a/corpus/main.txt
+++ b/corpus/main.txt
@@ -114,12 +114,14 @@ Custom tags
 Comments
 ==================================
 <!-- hello -->
+<!-- world ->-> -- > ->->->-- -> still comment -->
 <div>
   <!-- <span>something</span> -->
 </div>
 ---
 
 (fragment
+  (comment)
   (comment)
   (text)
   (element

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -108,7 +108,6 @@ struct Scanner {
             lexer->mark_end(lexer);
             return true;
           }
-          break;
         default:
           dashes = 0;
       }


### PR DESCRIPTION
HTML comments (to my knowledge) can only end with `-->`. Currently, the dash count is not reset when a `>` is seen, so the parser will accept `->->` as closing the comment (this can be seen in Atom).

The change removes the `break` keyword, so it will continue into the default behaviour and reset the dash count. I considered adding `dashes = 0` above instead, but removing `break` felt cleaner.

Also added tests to prevent regressions.