### PR TITLE
Correctly cast `name_length`

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -71,7 +71,7 @@ struct Scanner {
         Tag &tag = tags[j];
         tag.type = static_cast<TagType>(buffer[i++]);
         if (tag.type == CUSTOM) {
-          uint16_t name_length = (uint16_t)buffer[i++];
+          uint16_t name_length = static_cast<uint8_t>(buffer[i++]);
           tag.custom_tag_name.assign(&buffer[i], &buffer[i + name_length]);
           i += name_length;
         }


### PR DESCRIPTION
`buffer[i++]` is a `signed char` so this cast does not correctly handle
negative values. If a custom tag has a length greater than 128 then
`buffer[i++]` is negative and so the `(uint16_t)` cast will cast it to a large
unsigned integer. This causes an out-of-bound read when reading the tag name.

We need to cast `name_length` to a `uint8_t` first, then widen to a `uint16_t`.

/cc @anglinb who helped triage this ✨ 