### PR TITLE
More details in package.json for npm-ing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,15 @@
   "name": "tree-sitter-html",
   "version": "0.15.0",
   "description": "HTML grammar for tree-sitter",
-  "main": "index.js",
+  "license": "MIT",
+  "homepage": "https://github.com/tree-sitter/tree-sitter-html",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/tree-sitter/tree-sitter-html.git"
+  },
+  "bugs": {
+    "url": "https://github.com/tree-sitter/tree-sitter-html/issues"
+  },
   "keywords": [
     "parser",
     "lexer"
@@ -11,7 +19,7 @@
     "Max Brunsfeld <maxbrunsfeld@gmail.com>",
     "Ashi Krishnan <queerviolet@github.com>"
   ],
-  "license": "MIT",
+  "main": "index.js",
   "dependencies": {
     "nan": "^2.10.0"
   },


### PR DESCRIPTION
# What does it do?

It adds more information for npm, and node package users, so they can find resources or create a PR.

Compare these two to see the difference:

<img width="383" alt="Screen Shot 2019-11-27 at 1 12 51 PM" src="https://user-images.githubusercontent.com/1634015/69756474-ddb88980-1117-11ea-90ed-8cc6a057ba5c.png">

<img width="393" alt="Screen Shot 2019-11-27 at 1 14 20 PM" src="https://user-images.githubusercontent.com/1634015/69756486-e4df9780-1117-11ea-9644-40d8563ad81f.png">

# How to test

No test is necessary because it's just meta data. The JSON parses correctly. `node -e 'console.log(require("./package.json"))'`