### PR TITLE
Don't skip leading whitespace in raw text elements

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -229,12 +229,12 @@ struct Scanner {
   }
 
   bool scan(TSLexer *lexer, const bool *valid_symbols) {
-    while (iswspace(lexer->lookahead)) {
-      lexer->advance(lexer, true);
-    }
-
     if (valid_symbols[RAW_TEXT] && !valid_symbols[START_TAG_NAME] && !valid_symbols[END_TAG_NAME]) {
       return scan_raw_text(lexer);
+    }
+
+    while (iswspace(lexer->lookahead)) {
+      lexer->advance(lexer, true);
     }
 
     switch (lexer->lookahead) {

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -123,6 +123,7 @@ struct TSLanguage {
     unsigned (*serialize)(void *, char *);
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
+  const TSStateId *primary_state_ids;
 };
 
 /*


### PR DESCRIPTION
Currently the external scanner code skips past leading whitespace when
invoked. In the case of raw text elements this is contrary to the HTML
standard: [1], [2]. Therefore we should check if we're processing raw text,
and only skip the whitespace if not.

I can't figure out a way to add a test which depends on the specific source
range, but if this is possible I can also add some additional tests for this.

Closes #40.

[1]: <https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-incdata>
[2]: <https://html.spec.whatwg.org/multipage/parsing.html#script-data-state>