### PR TITLE
scanner.cc: include <stdint.h> for UINT16_MAX etc.

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -4,6 +4,8 @@
 #include <string>
 #include <cwctype>
 #include <cstring>
+#include <stdint.h>
+
 #include "tag.h"
 
 namespace {


### PR DESCRIPTION
This is required on NetBSD, and should in theory not hurt others.