### PR TITLE
ci & extreme nested tag bug fix

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,20 @@
+module.exports = {
+  'env': {
+    'commonjs': true,
+    'es2021': true,
+  },
+  'extends': 'google',
+  'overrides': [
+  ],
+  'parserOptions': {
+    'ecmaVersion': 'latest',
+    'sourceType': 'module',
+  },
+  'rules': {
+    'indent': ['error', 2, {'SwitchCase': 1}],
+    'max-len': [
+      'error',
+      {'code': 160, 'ignoreComments': true, 'ignoreUrls': true, 'ignoreStrings': true},
+    ],
+  },
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm test
+
+  test_windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm run test-windows

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,22 @@
+name: Fuzz Parser
+
+on:
+  push:
+    paths:
+      - src/scanner.c
+  pull_request:
+    paths:
+      - src/scanner.c
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Parser fuzzing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: vigoux/tree-sitter-fuzz-action@v1
+        with:
+          language: html
+          external-scanner: src/scanner.c
+          time: 60

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install modules
+        run: npm install
+      - name: Run ESLint
+        run: npm run lint

--- a/grammar.js
+++ b/grammar.js
@@ -1,3 +1,15 @@
+/**
+ * @file HTML grammar for tree-sitter
+ * @author Max Brunsfeld
+ * @license MIT
+ */
+
+/* eslint-disable arrow-parens */
+/* eslint-disable camelcase */
+/* eslint-disable-next-line spaced-comment */
+/// <reference types="tree-sitter-cli/dsl" />
+// @ts-check
+
 module.exports = grammar({
   name: 'html',
 
@@ -25,10 +37,10 @@ module.exports = grammar({
       '<!',
       alias($._doctype, 'doctype'),
       /[^>]+/,
-      '>'
+      '>',
     ),
 
-    _doctype: $ => /[Dd][Oo][Cc][Tt][Yy][Pp][Ee]/,
+    _doctype: _ => /[Dd][Oo][Cc][Tt][Yy][Pp][Ee]/,
 
     _node: $ => choice(
       $.doctype,
@@ -37,68 +49,68 @@ module.exports = grammar({
       $.element,
       $.script_element,
       $.style_element,
-      $.erroneous_end_tag
+      $.erroneous_end_tag,
     ),
 
     element: $ => choice(
       seq(
         $.start_tag,
         repeat($._node),
-        choice($.end_tag, $._implicit_end_tag)
+        choice($.end_tag, $._implicit_end_tag),
       ),
-      $.self_closing_tag
+      $.self_closing_tag,
     ),
 
     script_element: $ => seq(
       alias($.script_start_tag, $.start_tag),
       optional($.raw_text),
-      $.end_tag
+      $.end_tag,
     ),
 
     style_element: $ => seq(
       alias($.style_start_tag, $.start_tag),
       optional($.raw_text),
-      $.end_tag
+      $.end_tag,
     ),
 
     start_tag: $ => seq(
       '<',
       alias($._start_tag_name, $.tag_name),
       repeat($.attribute),
-      '>'
+      '>',
     ),
 
     script_start_tag: $ => seq(
       '<',
       alias($._script_start_tag_name, $.tag_name),
       repeat($.attribute),
-      '>'
+      '>',
     ),
 
     style_start_tag: $ => seq(
       '<',
       alias($._style_start_tag_name, $.tag_name),
       repeat($.attribute),
-      '>'
+      '>',
     ),
 
     self_closing_tag: $ => seq(
       '<',
       alias($._start_tag_name, $.tag_name),
       repeat($.attribute),
-      '/>'
+      '/>',
     ),
 
     end_tag: $ => seq(
       '</',
       alias($._end_tag_name, $.tag_name),
-      '>'
+      '>',
     ),
 
     erroneous_end_tag: $ => seq(
       '</',
       $.erroneous_end_tag_name,
-      '>'
+      '>',
     ),
 
     attribute: $ => seq(
@@ -107,25 +119,25 @@ module.exports = grammar({
         '=',
         choice(
           $.attribute_value,
-          $.quoted_attribute_value
-        )
-      ))
+          $.quoted_attribute_value,
+        ),
+      )),
     ),
 
-    attribute_name: $ => /[^<>"'/=\s]+/,
+    attribute_name: _ => /[^<>"'/=\s]+/,
 
-    attribute_value: $ => /[^<>"'=\s]+/,
+    attribute_value: _ => /[^<>"'=\s]+/,
 
     // An entity can be named, numeric (decimal), or numeric (hexacecimal). The
     // longest entity name is 29 characters long, and the HTML spec says that
     // no more will ever be added.
-    entity: $ => /&(#([xX][0-9a-fA-F]{1,6}|[0-9]{1,5})|[A-Za-z]{1,30});/,
+    entity: _ => /&(#([xX][0-9a-fA-F]{1,6}|[0-9]{1,5})|[A-Za-z]{1,30});/,
 
     quoted_attribute_value: $ => choice(
-      seq("'", optional(alias(/[^']+/, $.attribute_value)), "'"),
-      seq('"', optional(alias(/[^"]+/, $.attribute_value)), '"')
+      seq('\'', optional(alias(/[^']+/, $.attribute_value)), '\''),
+      seq('"', optional(alias(/[^"]+/, $.attribute_value)), '"'),
     ),
 
-    text: $ => /[^<>&\s]([^<>&]*[^<>&\s])?/
-  }
+    text: _ => /[^<>&\s]([^<>&]*[^<>&\s])?/,
+  },
 });

--- a/package.json
+++ b/package.json
@@ -20,9 +20,13 @@
     "nan": "^2.14.0"
   },
   "devDependencies": {
+    "eslint": "^8.43.0",
+    "eslint-config-google": "^0.14.0",
     "tree-sitter-cli": "^0.20.8"
   },
   "scripts": {
+    "build": "tree-sitter generate && node-gyp build",
+    "lint": "eslint grammar.js",
     "test": "tree-sitter test && tree-sitter parse examples/*.html --quiet --time",
     "test-windows": "tree-sitter test"
   },

--- a/src/tag.h
+++ b/src/tag.h
@@ -313,7 +313,7 @@ Tag make_tag(TagType type, const char *name) {
         tag.custom_tag_name.len = strlen(name);
         tag.custom_tag_name.data =
             (char *)calloc(1, sizeof(char) * (tag.custom_tag_name.len + 1));
-        strcpy(tag.custom_tag_name.data, name);
+        strncpy(tag.custom_tag_name.data, name, tag.custom_tag_name.len);
     }
     return tag;
 }


### PR DESCRIPTION
@aryx 

Unfortunately running tree-sitter test didn't run max's tests in examples (because we don't have a script/parse-examples file like usual), so I overlooked one bug where if a user has thousands of nested tags they'll get cut off and error out - that is now fixed with a simple check in deserialize and realloc changed to account for this (zero out additional allocations). I also used strncpy where applicable as it's safer.

CI should now cover for any change that breaks **any** of these areas (it really should be in every tree-sitter repo)