### PR TITLE
fix: use tag_free to clear vector strings

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -46,7 +46,9 @@ typedef struct {
 
 #define VEC_POP(vec)                                                           \
     {                                                                          \
-        STRING_FREE(VEC_BACK(vec).custom_tag_name);                            \
+        if (VEC_BACK(vec).type == CUSTOM) {                                    \
+            tag_free(&VEC_BACK(vec));                                          \
+        }                                                                      \
         (vec).len--;                                                           \
     }
 
@@ -62,9 +64,7 @@ typedef struct {
 #define VEC_CLEAR(vec)                                                         \
     {                                                                          \
         for (int i = 0; i < (vec).len; i++) {                                  \
-            if ((vec).data[i].type == CUSTOM) {                                \
-                STRING_FREE((vec).data[i].custom_tag_name);                    \
-            }                                                                  \
+            tag_free(&(vec).data[i]);                                          \
         }                                                                      \
         (vec).len = 0;                                                         \
     }
@@ -320,8 +320,6 @@ bool scan_start_tag_name(Scanner *scanner, TSLexer *lexer) {
         return false;
     }
     Tag tag = for_name(tag_name.data);
-    if (tag.type == CUSTOM) {
-    }
     VEC_PUSH(scanner->tags, tag);
     switch (tag.type) {
         case SCRIPT:


### PR DESCRIPTION
tag_free checks the tag's type and only frees if it's custom

Though I'm not sure why - the original grammar deserialized by plucking the tag from the buffer, which I replicated as well as it caused some bugs if a new tag was created instead.

@maxbrunsfeld (from https://github.com/tree-sitter/tree-sitter-html/commit/fe479bea7558a434b3249e53fe97c1fa485d1c9d#r120183692)