### PR TITLE
Quiet an "Implicit conversion loses integer precision" warning when building for Mac

### DIFF
--- a/src/tag.h
+++ b/src/tag.h
@@ -311,7 +311,7 @@ static Tag make_tag(TagType type, const char *name) {
     Tag tag = new_tag();
     tag.type = type;
     if (type == CUSTOM) {
-        tag.custom_tag_name.len = strlen(name);
+        tag.custom_tag_name.len = (uint32_t)strlen(name);
         tag.custom_tag_name.data =
             (char *)calloc(1, sizeof(char) * (tag.custom_tag_name.len + 1));
         strncpy(tag.custom_tag_name.data, name, tag.custom_tag_name.len);


### PR DESCRIPTION
Without the cast in this PR, a warning is generated when building with "swift build", or with Xcode, and possibly when building directly with the clang compiler.

> Implicit conversion loses integer precision: 'unsigned long' to 'uint32_t' (aka 'unsigned int')

It seems from inspection the value is unlikely to ever exceed the limit of the 32 bit unsigned int, so casting seems like a safe way to quiet the warning.