### PR TITLE
Quiet a Swift Package Manager warning by removing reference to a directory that doesn't exist

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,6 @@ let package = Package(
                     "binding.gyp",
                     "bindings",
                     "Cargo.toml",
-                    "corpus",
                     "grammar.js",
                     "LICENSE",
                     "package.json",


### PR DESCRIPTION
Currently if you build in Xcode or with the Swift Package Manager from the command line, a warning is generated:

```
swift build
warning: 'tree-sitter-html': Invalid Exclude '/Users/daniel/Sources/tree-sitter-html/corpus': File not found.
```

Since the "corpus" directory is not a top-level directory in the project, it will never be found unless somebody manually creates it as part of a build process.

I believe the "exclude" section of the Package.json file is intended only to remove items that would otherwise be included by "sources" or "resources" section, so all of the items in the "exclude" section are probably no-ops, but the ones apart from corpus at least refer to existent files so they don't cause any warnings.
