### PR TITLE
chore: remove unused token types

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -13,9 +13,6 @@ enum TokenType {
     IMPLICIT_END_TAG,
     RAW_TEXT,
     COMMENT,
-    OMITTED_HTML_END_TAG,
-    OMITTED_HEAD_END_TAG,
-    OMITTED_BODY_END_TAG,
 };
 
 typedef struct {


### PR DESCRIPTION
These enum types appear to be entirely unused anywhere in the code, so they should be removed.