### PR TITLE
Support entity in attributes + Disallow comments in attributes

### DIFF
--- a/bindings/swift/TreeSitterHtml/html.h
+++ b/bindings/swift/TreeSitterHtml/html.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_HTML_H_
+#define TREE_SITTER_HTML_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+const TSLanguage *tree_sitter_html(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_HTML_H_

--- a/bindings/swift/TreeSitterHtmlTests/TreeSitterHtmlTests.swift
+++ b/bindings/swift/TreeSitterHtmlTests/TreeSitterHtmlTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+import SwiftTreeSitter
+import TreeSitterHtml
+
+final class TreeSitterHtmlTests: XCTestCase {
+    func testCanLoadGrammar() throws {
+        let parser = Parser()
+        let language = Language(language: tree_sitter_html())
+        XCTAssertNoThrow(try parser.setLanguage(language),
+                         "Error loading Html grammar")
+    }
+}

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -2,8 +2,9 @@
 (erroneous_end_tag_name) @tag.error
 (doctype) @constant
 (attribute_name) @attribute
-(attribute_value) @string
+(attribute_value_fragment) @string
 (comment) @comment
+(entity) @entity
 
 [
   "<"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -68,6 +68,10 @@
         {
           "type": "SYMBOL",
           "name": "erroneous_end_tag"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "comment"
         }
       ]
     },
@@ -365,15 +369,45 @@
     },
     "attribute_name": {
       "type": "PATTERN",
-      "value": "[^<>\"'/=\\s]+"
+      "value": "[^<>\"'/=\\s&]+"
+    },
+    "attribute_value_fragment": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "PATTERN",
+        "value": "[^<>\"'=\\s&]+"
+      }
     },
     "attribute_value": {
-      "type": "PATTERN",
-      "value": "[^<>\"'=\\s]+"
+      "type": "REPEAT1",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "attribute_value_fragment"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "entity"
+          }
+        ]
+      }
     },
     "entity": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "PATTERN",
+        "value": "&(#([xX][0-9a-fA-F]{1,6}|[0-9]{1,5})|[A-Za-z]{1,30});?"
+      }
+    },
+    "unescaped_single_attribute_value_fragment": {
       "type": "PATTERN",
-      "value": "&(#([xX][0-9a-fA-F]{1,6}|[0-9]{1,5})|[A-Za-z]{1,30});?"
+      "value": "[^'&]+"
+    },
+    "unescaped_double_attribute_value_fragment": {
+      "type": "PATTERN",
+      "value": "[^\"&]+"
     },
     "quoted_attribute_value": {
       "type": "CHOICE",
@@ -386,21 +420,25 @@
               "value": "'"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[^']+"
+              "type": "REPEAT",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "unescaped_single_attribute_value_fragment"
+                    },
+                    "named": true,
+                    "value": "attribute_value_fragment"
                   },
-                  "named": true,
-                  "value": "attribute_value"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+                  {
+                    "type": "SYMBOL",
+                    "name": "entity"
+                  }
+                ]
+              }
             },
             {
               "type": "STRING",
@@ -416,21 +454,25 @@
               "value": "\""
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[^\"]+"
+              "type": "REPEAT",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "unescaped_double_attribute_value_fragment"
+                    },
+                    "named": true,
+                    "value": "attribute_value_fragment"
                   },
-                  "named": true,
-                  "value": "attribute_value"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+                  {
+                    "type": "SYMBOL",
+                    "name": "entity"
+                  }
+                ]
+              }
             },
             {
               "type": "STRING",
@@ -442,14 +484,10 @@
     },
     "text": {
       "type": "PATTERN",
-      "value": "[^<>&\\s]([^<>&]*[^<>&\\s])?"
+      "value": "[^<>&]+"
     }
   },
   "extras": [
-    {
-      "type": "SYMBOL",
-      "name": "comment"
-    },
     {
       "type": "PATTERN",
       "value": "\\s+"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -23,6 +23,25 @@
     }
   },
   {
+    "type": "attribute_value",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "attribute_value_fragment",
+          "named": true
+        },
+        {
+          "type": "entity",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "doctype",
     "named": true,
     "fields": {}
@@ -35,6 +54,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "comment",
+          "named": true
+        },
         {
           "type": "doctype",
           "named": true
@@ -74,6 +97,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "comment",
+          "named": true
+        },
         {
           "type": "doctype",
           "named": true
@@ -152,11 +179,15 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
         {
-          "type": "attribute_value",
+          "type": "attribute_value_fragment",
+          "named": true
+        },
+        {
+          "type": "entity",
           "named": true
         }
       ]
@@ -283,7 +314,7 @@
     "named": true
   },
   {
-    "type": "attribute_value",
+    "type": "attribute_value_fragment",
     "named": true
   },
   {

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,9 +5,9 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 94
+#define STATE_COUNT 100
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 41
+#define SYMBOL_COUNT 45
 #define ALIAS_COUNT 0
 #define TOKEN_COUNT 25
 #define EXTERNAL_TOKEN_COUNT 9
@@ -25,12 +25,12 @@ enum ts_symbol_identifiers {
   anon_sym_LT_SLASH = 7,
   anon_sym_EQ = 8,
   sym_attribute_name = 9,
-  sym_attribute_value = 10,
+  sym_attribute_value_fragment = 10,
   sym_entity = 11,
-  anon_sym_SQUOTE = 12,
-  aux_sym_quoted_attribute_value_token1 = 13,
-  anon_sym_DQUOTE = 14,
-  aux_sym_quoted_attribute_value_token2 = 15,
+  sym_unescaped_single_attribute_value_fragment = 12,
+  sym_unescaped_double_attribute_value_fragment = 13,
+  anon_sym_SQUOTE = 14,
+  anon_sym_DQUOTE = 15,
   sym_text = 16,
   sym__start_tag_name = 17,
   sym__script_start_tag_name = 18,
@@ -53,9 +53,13 @@ enum ts_symbol_identifiers {
   sym_end_tag = 35,
   sym_erroneous_end_tag = 36,
   sym_attribute = 37,
-  sym_quoted_attribute_value = 38,
-  aux_sym_document_repeat1 = 39,
-  aux_sym_start_tag_repeat1 = 40,
+  sym_attribute_value = 38,
+  sym_quoted_attribute_value = 39,
+  aux_sym_document_repeat1 = 40,
+  aux_sym_start_tag_repeat1 = 41,
+  aux_sym_attribute_value_repeat1 = 42,
+  aux_sym_quoted_attribute_value_repeat1 = 43,
+  aux_sym_quoted_attribute_value_repeat2 = 44,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -69,12 +73,12 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_LT_SLASH] = "</",
   [anon_sym_EQ] = "=",
   [sym_attribute_name] = "attribute_name",
-  [sym_attribute_value] = "attribute_value",
+  [sym_attribute_value_fragment] = "attribute_value_fragment",
   [sym_entity] = "entity",
+  [sym_unescaped_single_attribute_value_fragment] = "attribute_value_fragment",
+  [sym_unescaped_double_attribute_value_fragment] = "attribute_value_fragment",
   [anon_sym_SQUOTE] = "'",
-  [aux_sym_quoted_attribute_value_token1] = "attribute_value",
   [anon_sym_DQUOTE] = "\"",
-  [aux_sym_quoted_attribute_value_token2] = "attribute_value",
   [sym_text] = "text",
   [sym__start_tag_name] = "tag_name",
   [sym__script_start_tag_name] = "tag_name",
@@ -97,9 +101,13 @@ static const char * const ts_symbol_names[] = {
   [sym_end_tag] = "end_tag",
   [sym_erroneous_end_tag] = "erroneous_end_tag",
   [sym_attribute] = "attribute",
+  [sym_attribute_value] = "attribute_value",
   [sym_quoted_attribute_value] = "quoted_attribute_value",
   [aux_sym_document_repeat1] = "document_repeat1",
   [aux_sym_start_tag_repeat1] = "start_tag_repeat1",
+  [aux_sym_attribute_value_repeat1] = "attribute_value_repeat1",
+  [aux_sym_quoted_attribute_value_repeat1] = "quoted_attribute_value_repeat1",
+  [aux_sym_quoted_attribute_value_repeat2] = "quoted_attribute_value_repeat2",
 };
 
 static const TSSymbol ts_symbol_map[] = {
@@ -113,12 +121,12 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_LT_SLASH] = anon_sym_LT_SLASH,
   [anon_sym_EQ] = anon_sym_EQ,
   [sym_attribute_name] = sym_attribute_name,
-  [sym_attribute_value] = sym_attribute_value,
+  [sym_attribute_value_fragment] = sym_attribute_value_fragment,
   [sym_entity] = sym_entity,
+  [sym_unescaped_single_attribute_value_fragment] = sym_attribute_value_fragment,
+  [sym_unescaped_double_attribute_value_fragment] = sym_attribute_value_fragment,
   [anon_sym_SQUOTE] = anon_sym_SQUOTE,
-  [aux_sym_quoted_attribute_value_token1] = sym_attribute_value,
   [anon_sym_DQUOTE] = anon_sym_DQUOTE,
-  [aux_sym_quoted_attribute_value_token2] = sym_attribute_value,
   [sym_text] = sym_text,
   [sym__start_tag_name] = sym__start_tag_name,
   [sym__script_start_tag_name] = sym__start_tag_name,
@@ -141,9 +149,13 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_end_tag] = sym_end_tag,
   [sym_erroneous_end_tag] = sym_erroneous_end_tag,
   [sym_attribute] = sym_attribute,
+  [sym_attribute_value] = sym_attribute_value,
   [sym_quoted_attribute_value] = sym_quoted_attribute_value,
   [aux_sym_document_repeat1] = aux_sym_document_repeat1,
   [aux_sym_start_tag_repeat1] = aux_sym_start_tag_repeat1,
+  [aux_sym_attribute_value_repeat1] = aux_sym_attribute_value_repeat1,
+  [aux_sym_quoted_attribute_value_repeat1] = aux_sym_quoted_attribute_value_repeat1,
+  [aux_sym_quoted_attribute_value_repeat2] = aux_sym_quoted_attribute_value_repeat2,
 };
 
 static const TSSymbolMetadata ts_symbol_metadata[] = {
@@ -187,7 +199,7 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [sym_attribute_value] = {
+  [sym_attribute_value_fragment] = {
     .visible = true,
     .named = true,
   },
@@ -195,21 +207,21 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_unescaped_single_attribute_value_fragment] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_unescaped_double_attribute_value_fragment] = {
+    .visible = true,
+    .named = true,
+  },
   [anon_sym_SQUOTE] = {
     .visible = true,
     .named = false,
   },
-  [aux_sym_quoted_attribute_value_token1] = {
-    .visible = true,
-    .named = true,
-  },
   [anon_sym_DQUOTE] = {
     .visible = true,
     .named = false,
-  },
-  [aux_sym_quoted_attribute_value_token2] = {
-    .visible = true,
-    .named = true,
   },
   [sym_text] = {
     .visible = true,
@@ -299,6 +311,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_attribute_value] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_quoted_attribute_value] = {
     .visible = true,
     .named = true,
@@ -308,6 +324,18 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [aux_sym_start_tag_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_attribute_value_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_quoted_attribute_value_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_quoted_attribute_value_repeat2] = {
     .visible = false,
     .named = false,
   },
@@ -330,7 +358,7 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [5] = 2,
   [6] = 6,
   [7] = 7,
-  [8] = 6,
+  [8] = 7,
   [9] = 9,
   [10] = 10,
   [11] = 11,
@@ -342,80 +370,86 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [17] = 17,
   [18] = 18,
   [19] = 19,
-  [20] = 9,
+  [20] = 20,
   [21] = 21,
-  [22] = 22,
-  [23] = 19,
-  [24] = 10,
-  [25] = 12,
-  [26] = 13,
-  [27] = 14,
-  [28] = 15,
-  [29] = 16,
-  [30] = 17,
-  [31] = 31,
-  [32] = 22,
-  [33] = 21,
-  [34] = 31,
-  [35] = 35,
-  [36] = 36,
+  [22] = 21,
+  [23] = 20,
+  [24] = 11,
+  [25] = 16,
+  [26] = 26,
+  [27] = 17,
+  [28] = 9,
+  [29] = 12,
+  [30] = 13,
+  [31] = 10,
+  [32] = 18,
+  [33] = 33,
+  [34] = 15,
+  [35] = 19,
+  [36] = 14,
   [37] = 37,
-  [38] = 36,
-  [39] = 37,
+  [38] = 38,
+  [39] = 38,
   [40] = 40,
-  [41] = 35,
-  [42] = 42,
+  [41] = 41,
+  [42] = 40,
   [43] = 43,
-  [44] = 44,
-  [45] = 45,
+  [44] = 37,
+  [45] = 41,
   [46] = 46,
-  [47] = 46,
-  [48] = 48,
+  [47] = 47,
+  [48] = 47,
   [49] = 49,
   [50] = 50,
-  [51] = 45,
+  [51] = 51,
   [52] = 52,
   [53] = 53,
-  [54] = 48,
-  [55] = 53,
+  [54] = 49,
+  [55] = 43,
   [56] = 56,
-  [57] = 52,
-  [58] = 56,
+  [57] = 57,
+  [58] = 52,
   [59] = 59,
-  [60] = 60,
+  [60] = 53,
   [61] = 61,
   [62] = 62,
-  [63] = 49,
-  [64] = 50,
-  [65] = 65,
-  [66] = 66,
+  [63] = 63,
+  [64] = 64,
+  [65] = 59,
+  [66] = 64,
   [67] = 67,
-  [68] = 59,
+  [68] = 68,
   [69] = 69,
-  [70] = 60,
-  [71] = 69,
+  [70] = 69,
+  [71] = 68,
   [72] = 72,
-  [73] = 72,
-  [74] = 62,
-  [75] = 75,
-  [76] = 75,
-  [77] = 77,
+  [73] = 73,
+  [74] = 74,
+  [75] = 67,
+  [76] = 76,
+  [77] = 62,
   [78] = 78,
-  [79] = 79,
-  [80] = 79,
+  [79] = 78,
+  [80] = 73,
   [81] = 81,
   [82] = 82,
-  [83] = 83,
-  [84] = 84,
+  [83] = 76,
+  [84] = 63,
   [85] = 85,
-  [86] = 78,
-  [87] = 82,
+  [86] = 86,
+  [87] = 87,
   [88] = 88,
-  [89] = 85,
-  [90] = 81,
-  [91] = 84,
-  [92] = 88,
-  [93] = 77,
+  [89] = 89,
+  [90] = 90,
+  [91] = 91,
+  [92] = 85,
+  [93] = 89,
+  [94] = 87,
+  [95] = 88,
+  [96] = 86,
+  [97] = 97,
+  [98] = 90,
+  [99] = 91,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -423,448 +457,610 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(18);
+      if (eof) ADVANCE(22);
       ADVANCE_MAP(
-        '"', 73,
-        '&', 3,
-        '\'', 70,
-        '/', 6,
-        '<', 24,
-        '=', 27,
-        '>', 22,
-        'D', 9,
-        'd', 9,
+        '"', 87,
+        '&', 4,
+        '\'', 86,
+        '/', 34,
+        '<', 28,
+        '=', 31,
+        '>', 26,
+        'D', 37,
+        'd', 37,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(0);
+          lookahead == ' ') SKIP(20);
+      if (lookahead != 0) ADVANCE(41);
       END_STATE();
     case 1:
-      if (lookahead == '"') ADVANCE(73);
-      if (lookahead == '\'') ADVANCE(70);
+      if (lookahead == '"') ADVANCE(87);
+      if (lookahead == '&') ADVANCE(4);
+      if (lookahead == '\'') ADVANCE(86);
+      if (lookahead == '/') ADVANCE(41);
+      if (lookahead == '>') ADVANCE(26);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(1);
+          lookahead == ' ') SKIP(3);
       if (lookahead != 0 &&
-          (lookahead < '<' || '>' < lookahead)) ADVANCE(29);
+          (lookahead < '<' || '>' < lookahead)) ADVANCE(33);
       END_STATE();
     case 2:
-      if (lookahead == '"') ADVANCE(73);
+      if (lookahead == '"') ADVANCE(87);
+      if (lookahead == '&') ADVANCE(4);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(74);
-      if (lookahead != 0) ADVANCE(75);
+          lookahead == ' ') ADVANCE(84);
+      if (lookahead != 0) ADVANCE(85);
       END_STATE();
     case 3:
-      if (lookahead == '#') ADVANCE(12);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
-      END_STATE();
-    case 4:
-      if (lookahead == '\'') ADVANCE(70);
+      if (lookahead == '"') ADVANCE(87);
+      if (lookahead == '\'') ADVANCE(86);
+      if (lookahead == '>') ADVANCE(26);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(71);
-      if (lookahead != 0) ADVANCE(72);
-      END_STATE();
-    case 5:
-      if (lookahead == '/') ADVANCE(6);
-      if (lookahead == '=') ADVANCE(27);
-      if (lookahead == '>') ADVANCE(22);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(5);
-      if (lookahead != 0 &&
-          lookahead != '"' &&
-          lookahead != '\'' &&
-          (lookahead < '<' || '>' < lookahead)) ADVANCE(28);
-      END_STATE();
-    case 6:
-      if (lookahead == '>') ADVANCE(25);
-      END_STATE();
-    case 7:
-      if (lookahead == 'C' ||
-          lookahead == 'c') ADVANCE(11);
-      END_STATE();
-    case 8:
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(23);
-      END_STATE();
-    case 9:
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(7);
-      END_STATE();
-    case 10:
-      if (lookahead == 'P' ||
-          lookahead == 'p') ADVANCE(8);
-      END_STATE();
-    case 11:
-      if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(13);
-      END_STATE();
-    case 12:
-      if (lookahead == 'X' ||
-          lookahead == 'x') ADVANCE(16);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(35);
-      END_STATE();
-    case 13:
-      if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(10);
-      END_STATE();
-    case 14:
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(14);
+          lookahead == ' ') SKIP(3);
       if (lookahead != 0 &&
           lookahead != '&' &&
-          lookahead != '<' &&
-          lookahead != '>') ADVANCE(76);
+          lookahead != '\'' &&
+          lookahead != '/' &&
+          (lookahead < '<' || '>' < lookahead)) ADVANCE(32);
+      END_STATE();
+    case 4:
+      if (lookahead == '#') ADVANCE(16);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
+      END_STATE();
+    case 5:
+      if (lookahead == '&') ADVANCE(4);
+      if (lookahead == '\'') ADVANCE(86);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(82);
+      if (lookahead != 0) ADVANCE(83);
+      END_STATE();
+    case 6:
+      if (lookahead == '&') ADVANCE(4);
+      if (lookahead == '/') ADVANCE(34);
+      if (lookahead == '>') ADVANCE(26);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(8);
+      if (lookahead != 0 &&
+          lookahead != '"' &&
+          lookahead != '&' &&
+          lookahead != '\'' &&
+          (lookahead < '<' || '>' < lookahead)) ADVANCE(33);
+      END_STATE();
+    case 7:
+      if (lookahead == '/') ADVANCE(9);
+      if (lookahead == '=') ADVANCE(31);
+      if (lookahead == '>') ADVANCE(26);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(7);
+      if (lookahead != 0 &&
+          lookahead != '"' &&
+          lookahead != '&' &&
+          lookahead != '\'' &&
+          (lookahead < '<' || '>' < lookahead)) ADVANCE(32);
+      END_STATE();
+    case 8:
+      if (lookahead == '/') ADVANCE(9);
+      if (lookahead == '>') ADVANCE(26);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(8);
+      if (lookahead != 0 &&
+          lookahead != '"' &&
+          lookahead != '&' &&
+          lookahead != '\'' &&
+          (lookahead < '<' || '>' < lookahead)) ADVANCE(32);
+      END_STATE();
+    case 9:
+      if (lookahead == '>') ADVANCE(29);
+      END_STATE();
+    case 10:
+      if (lookahead == 'C' ||
+          lookahead == 'c') ADVANCE(15);
+      END_STATE();
+    case 11:
+      if (lookahead == 'D' ||
+          lookahead == 'd') ADVANCE(13);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(11);
+      END_STATE();
+    case 12:
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(27);
+      END_STATE();
+    case 13:
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(10);
+      END_STATE();
+    case 14:
+      if (lookahead == 'P' ||
+          lookahead == 'p') ADVANCE(12);
       END_STATE();
     case 15:
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(20);
-      if (lookahead != 0 &&
-          lookahead != '>') ADVANCE(21);
+      if (lookahead == 'T' ||
+          lookahead == 't') ADVANCE(17);
       END_STATE();
     case 16:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(40);
+      if (lookahead == 'X' ||
+          lookahead == 'x') ADVANCE(19);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(47);
       END_STATE();
     case 17:
-      if (eof) ADVANCE(18);
-      if (lookahead == '&') ADVANCE(3);
-      if (lookahead == '<') ADVANCE(24);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(17);
-      if (lookahead != 0 &&
-          lookahead != '>') ADVANCE(76);
+      if (lookahead == 'Y' ||
+          lookahead == 'y') ADVANCE(14);
       END_STATE();
     case 18:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(24);
+      if (lookahead != 0 &&
+          lookahead != '>') ADVANCE(25);
       END_STATE();
     case 19:
-      ACCEPT_TOKEN(anon_sym_LT_BANG);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(52);
       END_STATE();
     case 20:
-      ACCEPT_TOKEN(aux_sym_doctype_token1);
+      if (eof) ADVANCE(22);
+      ADVANCE_MAP(
+        '"', 87,
+        '\'', 86,
+        '/', 9,
+        '<', 28,
+        '=', 31,
+        '>', 26,
+        'D', 13,
+        'd', 13,
+      );
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(20);
-      if (lookahead != 0 &&
-          lookahead != '>') ADVANCE(21);
+          lookahead == ' ') SKIP(20);
       END_STATE();
     case 21:
-      ACCEPT_TOKEN(aux_sym_doctype_token1);
+      if (eof) ADVANCE(22);
+      if (lookahead == '&') ADVANCE(4);
+      if (lookahead == '<') ADVANCE(28);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(88);
       if (lookahead != 0 &&
-          lookahead != '>') ADVANCE(21);
+          lookahead != '>') ADVANCE(89);
       END_STATE();
     case 22:
-      ACCEPT_TOKEN(anon_sym_GT);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 23:
-      ACCEPT_TOKEN(sym__doctype);
+      ACCEPT_TOKEN(anon_sym_LT_BANG);
       END_STATE();
     case 24:
-      ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == '!') ADVANCE(19);
-      if (lookahead == '/') ADVANCE(26);
+      ACCEPT_TOKEN(aux_sym_doctype_token1);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(24);
+      if (lookahead != 0 &&
+          lookahead != '>') ADVANCE(25);
       END_STATE();
     case 25:
-      ACCEPT_TOKEN(anon_sym_SLASH_GT);
+      ACCEPT_TOKEN(aux_sym_doctype_token1);
+      if (lookahead != 0 &&
+          lookahead != '>') ADVANCE(25);
       END_STATE();
     case 26:
-      ACCEPT_TOKEN(anon_sym_LT_SLASH);
+      ACCEPT_TOKEN(anon_sym_GT);
       END_STATE();
     case 27:
-      ACCEPT_TOKEN(anon_sym_EQ);
+      ACCEPT_TOKEN(sym__doctype);
       END_STATE();
     case 28:
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == '!') ADVANCE(23);
+      if (lookahead == '/') ADVANCE(30);
+      END_STATE();
+    case 29:
+      ACCEPT_TOKEN(anon_sym_SLASH_GT);
+      END_STATE();
+    case 30:
+      ACCEPT_TOKEN(anon_sym_LT_SLASH);
+      END_STATE();
+    case 31:
+      ACCEPT_TOKEN(anon_sym_EQ);
+      END_STATE();
+    case 32:
       ACCEPT_TOKEN(sym_attribute_name);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
           lookahead != '"' &&
+          lookahead != '&' &&
           lookahead != '\'' &&
           lookahead != '/' &&
-          (lookahead < '<' || '>' < lookahead)) ADVANCE(28);
+          (lookahead < '<' || '>' < lookahead)) ADVANCE(32);
       END_STATE();
-    case 29:
-      ACCEPT_TOKEN(sym_attribute_value);
+    case 33:
+      ACCEPT_TOKEN(sym_attribute_value_fragment);
+      if (lookahead == '/') ADVANCE(41);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
           lookahead != '"' &&
+          lookahead != '&' &&
           lookahead != '\'' &&
-          (lookahead < '<' || '>' < lookahead)) ADVANCE(29);
-      END_STATE();
-    case 30:
-      ACCEPT_TOKEN(sym_entity);
-      END_STATE();
-    case 31:
-      ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      END_STATE();
-    case 32:
-      ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(31);
-      END_STATE();
-    case 33:
-      ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(32);
+          (lookahead < '<' || '>' < lookahead)) ADVANCE(33);
       END_STATE();
     case 34:
-      ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(33);
+      ACCEPT_TOKEN(sym_attribute_value_fragment);
+      if (lookahead == '>') ADVANCE(29);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          lookahead != '"' &&
+          lookahead != '&' &&
+          lookahead != '\'' &&
+          (lookahead < '<' || '>' < lookahead)) ADVANCE(41);
       END_STATE();
     case 35:
-      ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(34);
+      ACCEPT_TOKEN(sym_attribute_value_fragment);
+      if (lookahead == 'C' ||
+          lookahead == 'c') ADVANCE(39);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          lookahead != '"' &&
+          lookahead != '&' &&
+          lookahead != '\'' &&
+          (lookahead < '<' || '>' < lookahead)) ADVANCE(41);
       END_STATE();
     case 36:
-      ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(31);
+      ACCEPT_TOKEN(sym_attribute_value_fragment);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(41);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          lookahead != '"' &&
+          lookahead != '&' &&
+          lookahead != '\'' &&
+          (lookahead < '<' || '>' < lookahead)) ADVANCE(41);
       END_STATE();
     case 37:
-      ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(36);
+      ACCEPT_TOKEN(sym_attribute_value_fragment);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(35);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          lookahead != '"' &&
+          lookahead != '&' &&
+          lookahead != '\'' &&
+          (lookahead < '<' || '>' < lookahead)) ADVANCE(41);
       END_STATE();
     case 38:
-      ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(37);
+      ACCEPT_TOKEN(sym_attribute_value_fragment);
+      if (lookahead == 'P' ||
+          lookahead == 'p') ADVANCE(36);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          lookahead != '"' &&
+          lookahead != '&' &&
+          lookahead != '\'' &&
+          (lookahead < '<' || '>' < lookahead)) ADVANCE(41);
       END_STATE();
     case 39:
-      ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(38);
+      ACCEPT_TOKEN(sym_attribute_value_fragment);
+      if (lookahead == 'T' ||
+          lookahead == 't') ADVANCE(40);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          lookahead != '"' &&
+          lookahead != '&' &&
+          lookahead != '\'' &&
+          (lookahead < '<' || '>' < lookahead)) ADVANCE(41);
       END_STATE();
     case 40:
-      ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(39);
+      ACCEPT_TOKEN(sym_attribute_value_fragment);
+      if (lookahead == 'Y' ||
+          lookahead == 'y') ADVANCE(38);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          lookahead != '"' &&
+          lookahead != '&' &&
+          lookahead != '\'' &&
+          (lookahead < '<' || '>' < lookahead)) ADVANCE(41);
       END_STATE();
     case 41:
-      ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(31);
+      ACCEPT_TOKEN(sym_attribute_value_fragment);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          lookahead != '"' &&
+          lookahead != '&' &&
+          lookahead != '\'' &&
+          (lookahead < '<' || '>' < lookahead)) ADVANCE(41);
       END_STATE();
     case 42:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(41);
       END_STATE();
     case 43:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(42);
+      if (lookahead == ';') ADVANCE(42);
       END_STATE();
     case 44:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(43);
+      if (lookahead == ';') ADVANCE(42);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(43);
       END_STATE();
     case 45:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(44);
+      if (lookahead == ';') ADVANCE(42);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(44);
       END_STATE();
     case 46:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(45);
+      if (lookahead == ';') ADVANCE(42);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(45);
       END_STATE();
     case 47:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(46);
+      if (lookahead == ';') ADVANCE(42);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(46);
       END_STATE();
     case 48:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(47);
+      if (lookahead == ';') ADVANCE(42);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(43);
       END_STATE();
     case 49:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(48);
+      if (lookahead == ';') ADVANCE(42);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(48);
       END_STATE();
     case 50:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(49);
+      if (lookahead == ';') ADVANCE(42);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(49);
       END_STATE();
     case 51:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(50);
+      if (lookahead == ';') ADVANCE(42);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(50);
       END_STATE();
     case 52:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(51);
+      if (lookahead == ';') ADVANCE(42);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(51);
       END_STATE();
     case 53:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
+      if (lookahead == ';') ADVANCE(42);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(52);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(43);
       END_STATE();
     case 54:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
+      if (lookahead == ';') ADVANCE(42);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
       END_STATE();
     case 55:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
+      if (lookahead == ';') ADVANCE(42);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
       END_STATE();
     case 56:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
+      if (lookahead == ';') ADVANCE(42);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(55);
       END_STATE();
     case 57:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
+      if (lookahead == ';') ADVANCE(42);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
       END_STATE();
     case 58:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
+      if (lookahead == ';') ADVANCE(42);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(57);
       END_STATE();
     case 59:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
+      if (lookahead == ';') ADVANCE(42);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(58);
       END_STATE();
     case 60:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
+      if (lookahead == ';') ADVANCE(42);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(59);
       END_STATE();
     case 61:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
+      if (lookahead == ';') ADVANCE(42);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
       END_STATE();
     case 62:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
+      if (lookahead == ';') ADVANCE(42);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(61);
       END_STATE();
     case 63:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
+      if (lookahead == ';') ADVANCE(42);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(62);
       END_STATE();
     case 64:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
+      if (lookahead == ';') ADVANCE(42);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(63);
       END_STATE();
     case 65:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
+      if (lookahead == ';') ADVANCE(42);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(64);
       END_STATE();
     case 66:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
+      if (lookahead == ';') ADVANCE(42);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(65);
       END_STATE();
     case 67:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
+      if (lookahead == ';') ADVANCE(42);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(66);
       END_STATE();
     case 68:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
+      if (lookahead == ';') ADVANCE(42);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(67);
       END_STATE();
     case 69:
       ACCEPT_TOKEN(sym_entity);
-      if (lookahead == ';') ADVANCE(30);
+      if (lookahead == ';') ADVANCE(42);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
       END_STATE();
     case 70:
-      ACCEPT_TOKEN(anon_sym_SQUOTE);
+      ACCEPT_TOKEN(sym_entity);
+      if (lookahead == ';') ADVANCE(42);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(69);
       END_STATE();
     case 71:
-      ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token1);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(71);
-      if (lookahead != 0 &&
-          lookahead != '\'') ADVANCE(72);
+      ACCEPT_TOKEN(sym_entity);
+      if (lookahead == ';') ADVANCE(42);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 72:
-      ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token1);
-      if (lookahead != 0 &&
-          lookahead != '\'') ADVANCE(72);
+      ACCEPT_TOKEN(sym_entity);
+      if (lookahead == ';') ADVANCE(42);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(71);
       END_STATE();
     case 73:
-      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      ACCEPT_TOKEN(sym_entity);
+      if (lookahead == ';') ADVANCE(42);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 74:
-      ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token2);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(74);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(75);
+      ACCEPT_TOKEN(sym_entity);
+      if (lookahead == ';') ADVANCE(42);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       END_STATE();
     case 75:
-      ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token2);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(75);
+      ACCEPT_TOKEN(sym_entity);
+      if (lookahead == ';') ADVANCE(42);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
       END_STATE();
     case 76:
+      ACCEPT_TOKEN(sym_entity);
+      if (lookahead == ';') ADVANCE(42);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
+      END_STATE();
+    case 77:
+      ACCEPT_TOKEN(sym_entity);
+      if (lookahead == ';') ADVANCE(42);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(76);
+      END_STATE();
+    case 78:
+      ACCEPT_TOKEN(sym_entity);
+      if (lookahead == ';') ADVANCE(42);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(77);
+      END_STATE();
+    case 79:
+      ACCEPT_TOKEN(sym_entity);
+      if (lookahead == ';') ADVANCE(42);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(78);
+      END_STATE();
+    case 80:
+      ACCEPT_TOKEN(sym_entity);
+      if (lookahead == ';') ADVANCE(42);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(79);
+      END_STATE();
+    case 81:
+      ACCEPT_TOKEN(sym_entity);
+      if (lookahead == ';') ADVANCE(42);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
+      END_STATE();
+    case 82:
+      ACCEPT_TOKEN(sym_unescaped_single_attribute_value_fragment);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(82);
+      if (lookahead != 0 &&
+          lookahead != '&' &&
+          lookahead != '\'') ADVANCE(83);
+      END_STATE();
+    case 83:
+      ACCEPT_TOKEN(sym_unescaped_single_attribute_value_fragment);
+      if (lookahead != 0 &&
+          lookahead != '&' &&
+          lookahead != '\'') ADVANCE(83);
+      END_STATE();
+    case 84:
+      ACCEPT_TOKEN(sym_unescaped_double_attribute_value_fragment);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(84);
+      if (lookahead != 0 &&
+          lookahead != '"' &&
+          lookahead != '&') ADVANCE(85);
+      END_STATE();
+    case 85:
+      ACCEPT_TOKEN(sym_unescaped_double_attribute_value_fragment);
+      if (lookahead != 0 &&
+          lookahead != '"' &&
+          lookahead != '&') ADVANCE(85);
+      END_STATE();
+    case 86:
+      ACCEPT_TOKEN(anon_sym_SQUOTE);
+      END_STATE();
+    case 87:
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      END_STATE();
+    case 88:
       ACCEPT_TOKEN(sym_text);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(14);
+          lookahead == ' ') ADVANCE(88);
       if (lookahead != 0 &&
           lookahead != '&' &&
           lookahead != '<' &&
-          lookahead != '>') ADVANCE(76);
+          lookahead != '>') ADVANCE(89);
+      END_STATE();
+    case 89:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead != 0 &&
+          lookahead != '&' &&
+          lookahead != '<' &&
+          lookahead != '>') ADVANCE(89);
       END_STATE();
     default:
       return false;
@@ -873,99 +1069,105 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0, .external_lex_state = 1},
-  [1] = {.lex_state = 17, .external_lex_state = 2},
-  [2] = {.lex_state = 17, .external_lex_state = 3},
-  [3] = {.lex_state = 17, .external_lex_state = 3},
-  [4] = {.lex_state = 17, .external_lex_state = 3},
-  [5] = {.lex_state = 17, .external_lex_state = 3},
-  [6] = {.lex_state = 17, .external_lex_state = 3},
-  [7] = {.lex_state = 17, .external_lex_state = 2},
-  [8] = {.lex_state = 17, .external_lex_state = 2},
-  [9] = {.lex_state = 17, .external_lex_state = 3},
-  [10] = {.lex_state = 17, .external_lex_state = 2},
-  [11] = {.lex_state = 17, .external_lex_state = 3},
-  [12] = {.lex_state = 17, .external_lex_state = 2},
-  [13] = {.lex_state = 17, .external_lex_state = 2},
-  [14] = {.lex_state = 17, .external_lex_state = 2},
-  [15] = {.lex_state = 17, .external_lex_state = 2},
-  [16] = {.lex_state = 17, .external_lex_state = 2},
-  [17] = {.lex_state = 17, .external_lex_state = 2},
-  [18] = {.lex_state = 17, .external_lex_state = 3},
-  [19] = {.lex_state = 17, .external_lex_state = 2},
-  [20] = {.lex_state = 17, .external_lex_state = 2},
-  [21] = {.lex_state = 17, .external_lex_state = 3},
-  [22] = {.lex_state = 17, .external_lex_state = 3},
-  [23] = {.lex_state = 17, .external_lex_state = 3},
-  [24] = {.lex_state = 17, .external_lex_state = 3},
-  [25] = {.lex_state = 17, .external_lex_state = 3},
-  [26] = {.lex_state = 17, .external_lex_state = 3},
-  [27] = {.lex_state = 17, .external_lex_state = 3},
-  [28] = {.lex_state = 17, .external_lex_state = 3},
-  [29] = {.lex_state = 17, .external_lex_state = 3},
-  [30] = {.lex_state = 17, .external_lex_state = 3},
-  [31] = {.lex_state = 17, .external_lex_state = 3},
-  [32] = {.lex_state = 17, .external_lex_state = 2},
-  [33] = {.lex_state = 17, .external_lex_state = 2},
-  [34] = {.lex_state = 17, .external_lex_state = 2},
-  [35] = {.lex_state = 5, .external_lex_state = 4},
-  [36] = {.lex_state = 5, .external_lex_state = 4},
-  [37] = {.lex_state = 5, .external_lex_state = 4},
-  [38] = {.lex_state = 5, .external_lex_state = 4},
-  [39] = {.lex_state = 5, .external_lex_state = 4},
-  [40] = {.lex_state = 5, .external_lex_state = 2},
-  [41] = {.lex_state = 5, .external_lex_state = 2},
-  [42] = {.lex_state = 5, .external_lex_state = 2},
-  [43] = {.lex_state = 5, .external_lex_state = 2},
-  [44] = {.lex_state = 5, .external_lex_state = 2},
-  [45] = {.lex_state = 5, .external_lex_state = 4},
-  [46] = {.lex_state = 1, .external_lex_state = 2},
-  [47] = {.lex_state = 1, .external_lex_state = 2},
-  [48] = {.lex_state = 0, .external_lex_state = 5},
-  [49] = {.lex_state = 5, .external_lex_state = 4},
-  [50] = {.lex_state = 5, .external_lex_state = 4},
-  [51] = {.lex_state = 5, .external_lex_state = 2},
-  [52] = {.lex_state = 0, .external_lex_state = 6},
-  [53] = {.lex_state = 0, .external_lex_state = 5},
-  [54] = {.lex_state = 0, .external_lex_state = 5},
-  [55] = {.lex_state = 0, .external_lex_state = 5},
-  [56] = {.lex_state = 5, .external_lex_state = 4},
-  [57] = {.lex_state = 0, .external_lex_state = 6},
-  [58] = {.lex_state = 5, .external_lex_state = 2},
-  [59] = {.lex_state = 0, .external_lex_state = 7},
-  [60] = {.lex_state = 0, .external_lex_state = 2},
-  [61] = {.lex_state = 0, .external_lex_state = 5},
-  [62] = {.lex_state = 2, .external_lex_state = 2},
-  [63] = {.lex_state = 5, .external_lex_state = 2},
-  [64] = {.lex_state = 5, .external_lex_state = 2},
-  [65] = {.lex_state = 0, .external_lex_state = 5},
+  [1] = {.lex_state = 21, .external_lex_state = 2},
+  [2] = {.lex_state = 21, .external_lex_state = 3},
+  [3] = {.lex_state = 21, .external_lex_state = 3},
+  [4] = {.lex_state = 21, .external_lex_state = 3},
+  [5] = {.lex_state = 21, .external_lex_state = 3},
+  [6] = {.lex_state = 21, .external_lex_state = 2},
+  [7] = {.lex_state = 21, .external_lex_state = 2},
+  [8] = {.lex_state = 21, .external_lex_state = 3},
+  [9] = {.lex_state = 21, .external_lex_state = 2},
+  [10] = {.lex_state = 21, .external_lex_state = 3},
+  [11] = {.lex_state = 21, .external_lex_state = 3},
+  [12] = {.lex_state = 21, .external_lex_state = 3},
+  [13] = {.lex_state = 21, .external_lex_state = 3},
+  [14] = {.lex_state = 21, .external_lex_state = 3},
+  [15] = {.lex_state = 21, .external_lex_state = 3},
+  [16] = {.lex_state = 21, .external_lex_state = 2},
+  [17] = {.lex_state = 21, .external_lex_state = 3},
+  [18] = {.lex_state = 1},
+  [19] = {.lex_state = 21, .external_lex_state = 3},
+  [20] = {.lex_state = 21, .external_lex_state = 3},
+  [21] = {.lex_state = 21, .external_lex_state = 2},
+  [22] = {.lex_state = 21, .external_lex_state = 3},
+  [23] = {.lex_state = 21, .external_lex_state = 2},
+  [24] = {.lex_state = 21, .external_lex_state = 2},
+  [25] = {.lex_state = 21, .external_lex_state = 3},
+  [26] = {.lex_state = 21, .external_lex_state = 3},
+  [27] = {.lex_state = 21, .external_lex_state = 2},
+  [28] = {.lex_state = 21, .external_lex_state = 3},
+  [29] = {.lex_state = 21, .external_lex_state = 2},
+  [30] = {.lex_state = 21, .external_lex_state = 2},
+  [31] = {.lex_state = 21, .external_lex_state = 2},
+  [32] = {.lex_state = 1},
+  [33] = {.lex_state = 21, .external_lex_state = 3},
+  [34] = {.lex_state = 21, .external_lex_state = 2},
+  [35] = {.lex_state = 21, .external_lex_state = 2},
+  [36] = {.lex_state = 21, .external_lex_state = 2},
+  [37] = {.lex_state = 6, .external_lex_state = 4},
+  [38] = {.lex_state = 6, .external_lex_state = 4},
+  [39] = {.lex_state = 1},
+  [40] = {.lex_state = 7, .external_lex_state = 4},
+  [41] = {.lex_state = 7, .external_lex_state = 4},
+  [42] = {.lex_state = 7, .external_lex_state = 4},
+  [43] = {.lex_state = 7, .external_lex_state = 4},
+  [44] = {.lex_state = 1},
+  [45] = {.lex_state = 7, .external_lex_state = 4},
+  [46] = {.lex_state = 7},
+  [47] = {.lex_state = 5},
+  [48] = {.lex_state = 5},
+  [49] = {.lex_state = 2},
+  [50] = {.lex_state = 7},
+  [51] = {.lex_state = 7},
+  [52] = {.lex_state = 5},
+  [53] = {.lex_state = 2},
+  [54] = {.lex_state = 2},
+  [55] = {.lex_state = 7},
+  [56] = {.lex_state = 5},
+  [57] = {.lex_state = 2},
+  [58] = {.lex_state = 5},
+  [59] = {.lex_state = 7, .external_lex_state = 4},
+  [60] = {.lex_state = 2},
+  [61] = {.lex_state = 7},
+  [62] = {.lex_state = 7, .external_lex_state = 4},
+  [63] = {.lex_state = 7, .external_lex_state = 4},
+  [64] = {.lex_state = 0, .external_lex_state = 5},
+  [65] = {.lex_state = 7},
   [66] = {.lex_state = 0, .external_lex_state = 5},
-  [67] = {.lex_state = 0, .external_lex_state = 5},
-  [68] = {.lex_state = 0, .external_lex_state = 7},
-  [69] = {.lex_state = 0, .external_lex_state = 2},
-  [70] = {.lex_state = 0, .external_lex_state = 2},
-  [71] = {.lex_state = 0, .external_lex_state = 2},
-  [72] = {.lex_state = 4, .external_lex_state = 2},
-  [73] = {.lex_state = 4, .external_lex_state = 2},
-  [74] = {.lex_state = 2, .external_lex_state = 2},
-  [75] = {.lex_state = 0, .external_lex_state = 2},
-  [76] = {.lex_state = 0, .external_lex_state = 2},
-  [77] = {.lex_state = 0, .external_lex_state = 2},
-  [78] = {.lex_state = 0, .external_lex_state = 2},
-  [79] = {.lex_state = 0, .external_lex_state = 2},
-  [80] = {.lex_state = 0, .external_lex_state = 2},
-  [81] = {.lex_state = 15, .external_lex_state = 2},
-  [82] = {.lex_state = 0, .external_lex_state = 2},
-  [83] = {.lex_state = 0, .external_lex_state = 2},
-  [84] = {.lex_state = 0, .external_lex_state = 2},
+  [67] = {.lex_state = 7, .external_lex_state = 4},
+  [68] = {.lex_state = 0, .external_lex_state = 6},
+  [69] = {.lex_state = 0, .external_lex_state = 6},
+  [70] = {.lex_state = 0, .external_lex_state = 6},
+  [71] = {.lex_state = 0, .external_lex_state = 6},
+  [72] = {.lex_state = 0, .external_lex_state = 6},
+  [73] = {.lex_state = 0},
+  [74] = {.lex_state = 0, .external_lex_state = 6},
+  [75] = {.lex_state = 7},
+  [76] = {.lex_state = 0, .external_lex_state = 7},
+  [77] = {.lex_state = 7},
+  [78] = {.lex_state = 0},
+  [79] = {.lex_state = 0},
+  [80] = {.lex_state = 0},
+  [81] = {.lex_state = 0, .external_lex_state = 6},
+  [82] = {.lex_state = 0, .external_lex_state = 6},
+  [83] = {.lex_state = 0, .external_lex_state = 7},
+  [84] = {.lex_state = 7},
   [85] = {.lex_state = 0, .external_lex_state = 8},
-  [86] = {.lex_state = 0, .external_lex_state = 2},
-  [87] = {.lex_state = 0, .external_lex_state = 2},
-  [88] = {.lex_state = 0, .external_lex_state = 9},
-  [89] = {.lex_state = 0, .external_lex_state = 8},
-  [90] = {.lex_state = 15, .external_lex_state = 2},
-  [91] = {.lex_state = 0, .external_lex_state = 2},
-  [92] = {.lex_state = 0, .external_lex_state = 9},
-  [93] = {.lex_state = 0, .external_lex_state = 2},
+  [86] = {.lex_state = 18},
+  [87] = {.lex_state = 0},
+  [88] = {.lex_state = 0},
+  [89] = {.lex_state = 0},
+  [90] = {.lex_state = 0, .external_lex_state = 9},
+  [91] = {.lex_state = 11},
+  [92] = {.lex_state = 0, .external_lex_state = 8},
+  [93] = {.lex_state = 0},
+  [94] = {.lex_state = 0},
+  [95] = {.lex_state = 0},
+  [96] = {.lex_state = 18},
+  [97] = {.lex_state = 0},
+  [98] = {.lex_state = 0, .external_lex_state = 9},
+  [99] = {.lex_state = 11},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -978,6 +1180,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_SLASH_GT] = ACTIONS(1),
     [anon_sym_LT_SLASH] = ACTIONS(1),
     [anon_sym_EQ] = ACTIONS(1),
+    [sym_attribute_value_fragment] = ACTIONS(1),
     [sym_entity] = ACTIONS(1),
     [anon_sym_SQUOTE] = ACTIONS(1),
     [anon_sym_DQUOTE] = ACTIONS(1),
@@ -988,89 +1191,56 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_erroneous_end_tag_name] = ACTIONS(1),
     [sym__implicit_end_tag] = ACTIONS(1),
     [sym_raw_text] = ACTIONS(1),
-    [sym_comment] = ACTIONS(3),
+    [sym_comment] = ACTIONS(1),
   },
   [1] = {
-    [sym_document] = STATE(83),
-    [sym_doctype] = STATE(7),
-    [sym__node] = STATE(7),
-    [sym_element] = STATE(7),
-    [sym_script_element] = STATE(7),
-    [sym_style_element] = STATE(7),
-    [sym_start_tag] = STATE(2),
-    [sym_script_start_tag] = STATE(48),
-    [sym_style_start_tag] = STATE(53),
-    [sym_self_closing_tag] = STATE(33),
-    [sym_erroneous_end_tag] = STATE(7),
-    [aux_sym_document_repeat1] = STATE(7),
-    [ts_builtin_sym_end] = ACTIONS(5),
-    [anon_sym_LT_BANG] = ACTIONS(7),
-    [anon_sym_LT] = ACTIONS(9),
-    [anon_sym_LT_SLASH] = ACTIONS(11),
-    [sym_entity] = ACTIONS(13),
-    [sym_text] = ACTIONS(13),
-    [sym_comment] = ACTIONS(3),
+    [sym_document] = STATE(97),
+    [sym_doctype] = STATE(6),
+    [sym__node] = STATE(6),
+    [sym_element] = STATE(6),
+    [sym_script_element] = STATE(6),
+    [sym_style_element] = STATE(6),
+    [sym_start_tag] = STATE(4),
+    [sym_script_start_tag] = STATE(70),
+    [sym_style_start_tag] = STATE(71),
+    [sym_self_closing_tag] = STATE(9),
+    [sym_erroneous_end_tag] = STATE(6),
+    [aux_sym_document_repeat1] = STATE(6),
+    [ts_builtin_sym_end] = ACTIONS(3),
+    [anon_sym_LT_BANG] = ACTIONS(5),
+    [anon_sym_LT] = ACTIONS(7),
+    [anon_sym_LT_SLASH] = ACTIONS(9),
+    [sym_entity] = ACTIONS(11),
+    [sym_text] = ACTIONS(11),
+    [sym_comment] = ACTIONS(11),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 12,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(15), 1,
+  [0] = 11,
+    ACTIONS(13), 1,
       anon_sym_LT_BANG,
-    ACTIONS(17), 1,
-      anon_sym_LT,
-    ACTIONS(19), 1,
-      anon_sym_LT_SLASH,
-    ACTIONS(23), 1,
-      sym__implicit_end_tag,
-    STATE(5), 1,
-      sym_start_tag,
-    STATE(21), 1,
-      sym_self_closing_tag,
-    STATE(32), 1,
-      sym_end_tag,
-    STATE(54), 1,
-      sym_script_start_tag,
-    STATE(55), 1,
-      sym_style_start_tag,
-    ACTIONS(21), 2,
-      sym_entity,
-      sym_text,
-    STATE(3), 7,
-      sym_doctype,
-      sym__node,
-      sym_element,
-      sym_script_element,
-      sym_style_element,
-      sym_erroneous_end_tag,
-      aux_sym_document_repeat1,
-  [44] = 12,
-    ACTIONS(3), 1,
-      sym_comment,
     ACTIONS(15), 1,
-      anon_sym_LT_BANG,
-    ACTIONS(17), 1,
       anon_sym_LT,
-    ACTIONS(19), 1,
+    ACTIONS(17), 1,
       anon_sym_LT_SLASH,
-    ACTIONS(27), 1,
+    ACTIONS(21), 1,
       sym__implicit_end_tag,
-    STATE(5), 1,
+    STATE(3), 1,
       sym_start_tag,
     STATE(14), 1,
       sym_end_tag,
-    STATE(21), 1,
+    STATE(28), 1,
       sym_self_closing_tag,
-    STATE(54), 1,
-      sym_script_start_tag,
-    STATE(55), 1,
+    STATE(68), 1,
       sym_style_start_tag,
-    ACTIONS(25), 2,
+    STATE(69), 1,
+      sym_script_start_tag,
+    ACTIONS(19), 3,
+      sym_comment,
       sym_entity,
       sym_text,
-    STATE(6), 7,
+    STATE(8), 7,
       sym_doctype,
       sym__node,
       sym_element,
@@ -1078,31 +1248,61 @@ static const uint16_t ts_small_parse_table[] = {
       sym_style_element,
       sym_erroneous_end_tag,
       aux_sym_document_repeat1,
-  [88] = 12,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(15), 1,
+  [42] = 11,
+    ACTIONS(13), 1,
       anon_sym_LT_BANG,
-    ACTIONS(17), 1,
+    ACTIONS(15), 1,
       anon_sym_LT,
-    ACTIONS(29), 1,
+    ACTIONS(17), 1,
+      anon_sym_LT_SLASH,
+    ACTIONS(25), 1,
+      sym__implicit_end_tag,
+    STATE(3), 1,
+      sym_start_tag,
+    STATE(25), 1,
+      sym_end_tag,
+    STATE(28), 1,
+      sym_self_closing_tag,
+    STATE(68), 1,
+      sym_style_start_tag,
+    STATE(69), 1,
+      sym_script_start_tag,
+    ACTIONS(23), 3,
+      sym_comment,
+      sym_entity,
+      sym_text,
+    STATE(2), 7,
+      sym_doctype,
+      sym__node,
+      sym_element,
+      sym_script_element,
+      sym_style_element,
+      sym_erroneous_end_tag,
+      aux_sym_document_repeat1,
+  [84] = 11,
+    ACTIONS(13), 1,
+      anon_sym_LT_BANG,
+    ACTIONS(15), 1,
+      anon_sym_LT,
+    ACTIONS(27), 1,
       anon_sym_LT_SLASH,
     ACTIONS(31), 1,
       sym__implicit_end_tag,
-    STATE(5), 1,
+    STATE(3), 1,
       sym_start_tag,
-    STATE(21), 1,
-      sym_self_closing_tag,
-    STATE(27), 1,
+    STATE(16), 1,
       sym_end_tag,
-    STATE(54), 1,
-      sym_script_start_tag,
-    STATE(55), 1,
+    STATE(28), 1,
+      sym_self_closing_tag,
+    STATE(68), 1,
       sym_style_start_tag,
-    ACTIONS(25), 2,
+    STATE(69), 1,
+      sym_script_start_tag,
+    ACTIONS(29), 3,
+      sym_comment,
       sym_entity,
       sym_text,
-    STATE(6), 7,
+    STATE(5), 7,
       sym_doctype,
       sym__node,
       sym_element,
@@ -1110,88 +1310,114 @@ static const uint16_t ts_small_parse_table[] = {
       sym_style_element,
       sym_erroneous_end_tag,
       aux_sym_document_repeat1,
-  [132] = 12,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(15), 1,
+  [126] = 11,
+    ACTIONS(13), 1,
       anon_sym_LT_BANG,
-    ACTIONS(17), 1,
+    ACTIONS(15), 1,
       anon_sym_LT,
-    ACTIONS(29), 1,
+    ACTIONS(27), 1,
+      anon_sym_LT_SLASH,
+    ACTIONS(33), 1,
+      sym__implicit_end_tag,
+    STATE(3), 1,
+      sym_start_tag,
+    STATE(28), 1,
+      sym_self_closing_tag,
+    STATE(36), 1,
+      sym_end_tag,
+    STATE(68), 1,
+      sym_style_start_tag,
+    STATE(69), 1,
+      sym_script_start_tag,
+    ACTIONS(19), 3,
+      sym_comment,
+      sym_entity,
+      sym_text,
+    STATE(8), 7,
+      sym_doctype,
+      sym__node,
+      sym_element,
+      sym_script_element,
+      sym_style_element,
+      sym_erroneous_end_tag,
+      aux_sym_document_repeat1,
+  [168] = 10,
+    ACTIONS(5), 1,
+      anon_sym_LT_BANG,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
       anon_sym_LT_SLASH,
     ACTIONS(35), 1,
-      sym__implicit_end_tag,
-    STATE(5), 1,
-      sym_start_tag,
-    STATE(21), 1,
-      sym_self_closing_tag,
-    STATE(22), 1,
-      sym_end_tag,
-    STATE(54), 1,
-      sym_script_start_tag,
-    STATE(55), 1,
-      sym_style_start_tag,
-    ACTIONS(33), 2,
-      sym_entity,
-      sym_text,
-    STATE(4), 7,
-      sym_doctype,
-      sym__node,
-      sym_element,
-      sym_script_element,
-      sym_style_element,
-      sym_erroneous_end_tag,
-      aux_sym_document_repeat1,
-  [176] = 11,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(37), 1,
-      anon_sym_LT_BANG,
-    ACTIONS(40), 1,
-      anon_sym_LT,
-    ACTIONS(43), 1,
-      anon_sym_LT_SLASH,
-    ACTIONS(49), 1,
-      sym__implicit_end_tag,
-    STATE(5), 1,
-      sym_start_tag,
-    STATE(21), 1,
-      sym_self_closing_tag,
-    STATE(54), 1,
-      sym_script_start_tag,
-    STATE(55), 1,
-      sym_style_start_tag,
-    ACTIONS(46), 2,
-      sym_entity,
-      sym_text,
-    STATE(6), 7,
-      sym_doctype,
-      sym__node,
-      sym_element,
-      sym_script_element,
-      sym_style_element,
-      sym_erroneous_end_tag,
-      aux_sym_document_repeat1,
-  [217] = 11,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(7), 1,
-      anon_sym_LT_BANG,
-    ACTIONS(9), 1,
-      anon_sym_LT,
-    ACTIONS(11), 1,
-      anon_sym_LT_SLASH,
-    ACTIONS(51), 1,
       ts_builtin_sym_end,
-    STATE(2), 1,
+    STATE(4), 1,
       sym_start_tag,
-    STATE(33), 1,
+    STATE(9), 1,
       sym_self_closing_tag,
-    STATE(48), 1,
+    STATE(70), 1,
       sym_script_start_tag,
-    STATE(53), 1,
+    STATE(71), 1,
       sym_style_start_tag,
-    ACTIONS(53), 2,
+    ACTIONS(37), 3,
+      sym_comment,
+      sym_entity,
+      sym_text,
+    STATE(7), 7,
+      sym_doctype,
+      sym__node,
+      sym_element,
+      sym_script_element,
+      sym_style_element,
+      sym_erroneous_end_tag,
+      aux_sym_document_repeat1,
+  [207] = 10,
+    ACTIONS(39), 1,
+      ts_builtin_sym_end,
+    ACTIONS(41), 1,
+      anon_sym_LT_BANG,
+    ACTIONS(44), 1,
+      anon_sym_LT,
+    ACTIONS(47), 1,
+      anon_sym_LT_SLASH,
+    STATE(4), 1,
+      sym_start_tag,
+    STATE(9), 1,
+      sym_self_closing_tag,
+    STATE(70), 1,
+      sym_script_start_tag,
+    STATE(71), 1,
+      sym_style_start_tag,
+    ACTIONS(50), 3,
+      sym_comment,
+      sym_entity,
+      sym_text,
+    STATE(7), 7,
+      sym_doctype,
+      sym__node,
+      sym_element,
+      sym_script_element,
+      sym_style_element,
+      sym_erroneous_end_tag,
+      aux_sym_document_repeat1,
+  [246] = 10,
+    ACTIONS(39), 1,
+      sym__implicit_end_tag,
+    ACTIONS(53), 1,
+      anon_sym_LT_BANG,
+    ACTIONS(56), 1,
+      anon_sym_LT,
+    ACTIONS(59), 1,
+      anon_sym_LT_SLASH,
+    STATE(3), 1,
+      sym_start_tag,
+    STATE(28), 1,
+      sym_self_closing_tag,
+    STATE(68), 1,
+      sym_style_start_tag,
+    STATE(69), 1,
+      sym_script_start_tag,
+    ACTIONS(62), 3,
+      sym_comment,
       sym_entity,
       sym_text,
     STATE(8), 7,
@@ -1202,972 +1428,919 @@ static const uint16_t ts_small_parse_table[] = {
       sym_style_element,
       sym_erroneous_end_tag,
       aux_sym_document_repeat1,
-  [258] = 11,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(49), 1,
-      ts_builtin_sym_end,
-    ACTIONS(55), 1,
+  [285] = 2,
+    ACTIONS(67), 3,
       anon_sym_LT_BANG,
-    ACTIONS(58), 1,
       anon_sym_LT,
-    ACTIONS(61), 1,
       anon_sym_LT_SLASH,
-    STATE(2), 1,
-      sym_start_tag,
-    STATE(33), 1,
-      sym_self_closing_tag,
-    STATE(48), 1,
-      sym_script_start_tag,
-    STATE(53), 1,
-      sym_style_start_tag,
-    ACTIONS(64), 2,
+    ACTIONS(65), 4,
+      sym_comment,
+      ts_builtin_sym_end,
       sym_entity,
       sym_text,
-    STATE(8), 7,
-      sym_doctype,
-      sym__node,
-      sym_element,
-      sym_script_element,
-      sym_style_element,
-      sym_erroneous_end_tag,
-      aux_sym_document_repeat1,
-  [299] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(69), 1,
+  [297] = 2,
+    ACTIONS(69), 3,
+      anon_sym_LT_BANG,
       anon_sym_LT,
-    ACTIONS(67), 5,
+      anon_sym_LT_SLASH,
+    ACTIONS(71), 4,
       sym__implicit_end_tag,
-      anon_sym_LT_BANG,
-      anon_sym_LT_SLASH,
+      sym_comment,
       sym_entity,
       sym_text,
-  [313] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(73), 1,
-      anon_sym_LT,
-    ACTIONS(71), 5,
-      ts_builtin_sym_end,
+  [309] = 2,
+    ACTIONS(73), 3,
       anon_sym_LT_BANG,
-      anon_sym_LT_SLASH,
-      sym_entity,
-      sym_text,
-  [327] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(77), 1,
       anon_sym_LT,
-    ACTIONS(75), 5,
+      anon_sym_LT_SLASH,
+    ACTIONS(75), 4,
       sym__implicit_end_tag,
-      anon_sym_LT_BANG,
-      anon_sym_LT_SLASH,
+      sym_comment,
       sym_entity,
       sym_text,
-  [341] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(81), 1,
+  [321] = 2,
+    ACTIONS(77), 3,
+      anon_sym_LT_BANG,
       anon_sym_LT,
-    ACTIONS(79), 5,
-      ts_builtin_sym_end,
-      anon_sym_LT_BANG,
       anon_sym_LT_SLASH,
+    ACTIONS(79), 4,
+      sym__implicit_end_tag,
+      sym_comment,
       sym_entity,
       sym_text,
-  [355] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(85), 1,
+  [333] = 2,
+    ACTIONS(81), 3,
+      anon_sym_LT_BANG,
       anon_sym_LT,
-    ACTIONS(83), 5,
-      ts_builtin_sym_end,
-      anon_sym_LT_BANG,
       anon_sym_LT_SLASH,
+    ACTIONS(83), 4,
+      sym__implicit_end_tag,
+      sym_comment,
       sym_entity,
       sym_text,
-  [369] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(89), 1,
+  [345] = 2,
+    ACTIONS(85), 3,
+      anon_sym_LT_BANG,
       anon_sym_LT,
-    ACTIONS(87), 5,
-      ts_builtin_sym_end,
-      anon_sym_LT_BANG,
       anon_sym_LT_SLASH,
+    ACTIONS(87), 4,
+      sym__implicit_end_tag,
+      sym_comment,
       sym_entity,
       sym_text,
-  [383] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(93), 1,
+  [357] = 2,
+    ACTIONS(89), 3,
+      anon_sym_LT_BANG,
       anon_sym_LT,
-    ACTIONS(91), 5,
-      ts_builtin_sym_end,
-      anon_sym_LT_BANG,
       anon_sym_LT_SLASH,
+    ACTIONS(91), 4,
+      sym__implicit_end_tag,
+      sym_comment,
       sym_entity,
       sym_text,
-  [397] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(97), 1,
+  [369] = 2,
+    ACTIONS(95), 3,
+      anon_sym_LT_BANG,
       anon_sym_LT,
-    ACTIONS(95), 5,
-      ts_builtin_sym_end,
-      anon_sym_LT_BANG,
       anon_sym_LT_SLASH,
+    ACTIONS(93), 4,
+      sym_comment,
+      ts_builtin_sym_end,
       sym_entity,
       sym_text,
-  [411] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(101), 1,
+  [381] = 2,
+    ACTIONS(97), 3,
+      anon_sym_LT_BANG,
       anon_sym_LT,
-    ACTIONS(99), 5,
-      ts_builtin_sym_end,
-      anon_sym_LT_BANG,
       anon_sym_LT_SLASH,
+    ACTIONS(99), 4,
+      sym__implicit_end_tag,
+      sym_comment,
       sym_entity,
       sym_text,
-  [425] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
+  [393] = 5,
+    ACTIONS(103), 1,
+      anon_sym_SQUOTE,
     ACTIONS(105), 1,
-      anon_sym_LT,
-    ACTIONS(103), 5,
-      sym__implicit_end_tag,
+      anon_sym_DQUOTE,
+    STATE(44), 1,
+      aux_sym_attribute_value_repeat1,
+    ACTIONS(101), 2,
+      sym_attribute_value_fragment,
+      sym_entity,
+    STATE(84), 2,
+      sym_attribute_value,
+      sym_quoted_attribute_value,
+  [411] = 2,
+    ACTIONS(107), 3,
       anon_sym_LT_BANG,
+      anon_sym_LT,
       anon_sym_LT_SLASH,
+    ACTIONS(109), 4,
+      sym__implicit_end_tag,
+      sym_comment,
       sym_entity,
       sym_text,
-  [439] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(109), 1,
+  [423] = 2,
+    ACTIONS(111), 3,
+      anon_sym_LT_BANG,
       anon_sym_LT,
-    ACTIONS(107), 5,
+      anon_sym_LT_SLASH,
+    ACTIONS(113), 4,
+      sym__implicit_end_tag,
+      sym_comment,
+      sym_entity,
+      sym_text,
+  [435] = 2,
+    ACTIONS(117), 3,
+      anon_sym_LT_BANG,
+      anon_sym_LT,
+      anon_sym_LT_SLASH,
+    ACTIONS(115), 4,
+      sym_comment,
       ts_builtin_sym_end,
-      anon_sym_LT_BANG,
-      anon_sym_LT_SLASH,
       sym_entity,
       sym_text,
-  [453] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(69), 1,
+  [447] = 2,
+    ACTIONS(117), 3,
+      anon_sym_LT_BANG,
       anon_sym_LT,
-    ACTIONS(67), 5,
+      anon_sym_LT_SLASH,
+    ACTIONS(115), 4,
+      sym__implicit_end_tag,
+      sym_comment,
+      sym_entity,
+      sym_text,
+  [459] = 2,
+    ACTIONS(111), 3,
+      anon_sym_LT_BANG,
+      anon_sym_LT,
+      anon_sym_LT_SLASH,
+    ACTIONS(113), 4,
+      sym_comment,
       ts_builtin_sym_end,
-      anon_sym_LT_BANG,
-      anon_sym_LT_SLASH,
       sym_entity,
       sym_text,
-  [467] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(113), 1,
-      anon_sym_LT,
-    ACTIONS(111), 5,
-      sym__implicit_end_tag,
+  [471] = 2,
+    ACTIONS(73), 3,
       anon_sym_LT_BANG,
-      anon_sym_LT_SLASH,
-      sym_entity,
-      sym_text,
-  [481] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(117), 1,
       anon_sym_LT,
-    ACTIONS(115), 5,
-      sym__implicit_end_tag,
-      anon_sym_LT_BANG,
       anon_sym_LT_SLASH,
-      sym_entity,
-      sym_text,
-  [495] = 3,
-    ACTIONS(3), 1,
+    ACTIONS(75), 4,
       sym_comment,
-    ACTIONS(109), 1,
-      anon_sym_LT,
-    ACTIONS(107), 5,
-      sym__implicit_end_tag,
-      anon_sym_LT_BANG,
-      anon_sym_LT_SLASH,
-      sym_entity,
-      sym_text,
-  [509] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(73), 1,
-      anon_sym_LT,
-    ACTIONS(71), 5,
-      sym__implicit_end_tag,
-      anon_sym_LT_BANG,
-      anon_sym_LT_SLASH,
-      sym_entity,
-      sym_text,
-  [523] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(81), 1,
-      anon_sym_LT,
-    ACTIONS(79), 5,
-      sym__implicit_end_tag,
-      anon_sym_LT_BANG,
-      anon_sym_LT_SLASH,
-      sym_entity,
-      sym_text,
-  [537] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(85), 1,
-      anon_sym_LT,
-    ACTIONS(83), 5,
-      sym__implicit_end_tag,
-      anon_sym_LT_BANG,
-      anon_sym_LT_SLASH,
-      sym_entity,
-      sym_text,
-  [551] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(89), 1,
-      anon_sym_LT,
-    ACTIONS(87), 5,
-      sym__implicit_end_tag,
-      anon_sym_LT_BANG,
-      anon_sym_LT_SLASH,
-      sym_entity,
-      sym_text,
-  [565] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(93), 1,
-      anon_sym_LT,
-    ACTIONS(91), 5,
-      sym__implicit_end_tag,
-      anon_sym_LT_BANG,
-      anon_sym_LT_SLASH,
-      sym_entity,
-      sym_text,
-  [579] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(97), 1,
-      anon_sym_LT,
-    ACTIONS(95), 5,
-      sym__implicit_end_tag,
-      anon_sym_LT_BANG,
-      anon_sym_LT_SLASH,
-      sym_entity,
-      sym_text,
-  [593] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(101), 1,
-      anon_sym_LT,
-    ACTIONS(99), 5,
-      sym__implicit_end_tag,
-      anon_sym_LT_BANG,
-      anon_sym_LT_SLASH,
-      sym_entity,
-      sym_text,
-  [607] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(121), 1,
-      anon_sym_LT,
-    ACTIONS(119), 5,
-      sym__implicit_end_tag,
-      anon_sym_LT_BANG,
-      anon_sym_LT_SLASH,
-      sym_entity,
-      sym_text,
-  [621] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(117), 1,
-      anon_sym_LT,
-    ACTIONS(115), 5,
       ts_builtin_sym_end,
-      anon_sym_LT_BANG,
-      anon_sym_LT_SLASH,
       sym_entity,
       sym_text,
-  [635] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(113), 1,
+  [483] = 2,
+    ACTIONS(95), 3,
+      anon_sym_LT_BANG,
       anon_sym_LT,
-    ACTIONS(111), 5,
-      ts_builtin_sym_end,
-      anon_sym_LT_BANG,
       anon_sym_LT_SLASH,
+    ACTIONS(93), 4,
+      sym__implicit_end_tag,
+      sym_comment,
       sym_entity,
       sym_text,
-  [649] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(121), 1,
+  [495] = 2,
+    ACTIONS(119), 3,
+      anon_sym_LT_BANG,
       anon_sym_LT,
-    ACTIONS(119), 5,
-      ts_builtin_sym_end,
-      anon_sym_LT_BANG,
       anon_sym_LT_SLASH,
+    ACTIONS(121), 4,
+      sym__implicit_end_tag,
+      sym_comment,
       sym_entity,
       sym_text,
-  [663] = 4,
-    ACTIONS(3), 1,
+  [507] = 2,
+    ACTIONS(97), 3,
+      anon_sym_LT_BANG,
+      anon_sym_LT,
+      anon_sym_LT_SLASH,
+    ACTIONS(99), 4,
       sym_comment,
+      ts_builtin_sym_end,
+      sym_entity,
+      sym_text,
+  [519] = 2,
+    ACTIONS(67), 3,
+      anon_sym_LT_BANG,
+      anon_sym_LT,
+      anon_sym_LT_SLASH,
+    ACTIONS(65), 4,
+      sym__implicit_end_tag,
+      sym_comment,
+      sym_entity,
+      sym_text,
+  [531] = 2,
+    ACTIONS(77), 3,
+      anon_sym_LT_BANG,
+      anon_sym_LT,
+      anon_sym_LT_SLASH,
+    ACTIONS(79), 4,
+      sym_comment,
+      ts_builtin_sym_end,
+      sym_entity,
+      sym_text,
+  [543] = 2,
+    ACTIONS(81), 3,
+      anon_sym_LT_BANG,
+      anon_sym_LT,
+      anon_sym_LT_SLASH,
+    ACTIONS(83), 4,
+      sym_comment,
+      ts_builtin_sym_end,
+      sym_entity,
+      sym_text,
+  [555] = 2,
+    ACTIONS(69), 3,
+      anon_sym_LT_BANG,
+      anon_sym_LT,
+      anon_sym_LT_SLASH,
+    ACTIONS(71), 4,
+      sym_comment,
+      ts_builtin_sym_end,
+      sym_entity,
+      sym_text,
+  [567] = 5,
     ACTIONS(125), 1,
-      sym_attribute_name,
+      anon_sym_SQUOTE,
+    ACTIONS(127), 1,
+      anon_sym_DQUOTE,
+    STATE(37), 1,
+      aux_sym_attribute_value_repeat1,
     ACTIONS(123), 2,
+      sym_attribute_value_fragment,
+      sym_entity,
+    STATE(63), 2,
+      sym_attribute_value,
+      sym_quoted_attribute_value,
+  [585] = 2,
+    ACTIONS(129), 3,
+      anon_sym_LT_BANG,
+      anon_sym_LT,
+      anon_sym_LT_SLASH,
+    ACTIONS(131), 4,
+      sym__implicit_end_tag,
+      sym_comment,
+      sym_entity,
+      sym_text,
+  [597] = 2,
+    ACTIONS(89), 3,
+      anon_sym_LT_BANG,
+      anon_sym_LT,
+      anon_sym_LT_SLASH,
+    ACTIONS(91), 4,
+      sym_comment,
+      ts_builtin_sym_end,
+      sym_entity,
+      sym_text,
+  [609] = 2,
+    ACTIONS(107), 3,
+      anon_sym_LT_BANG,
+      anon_sym_LT,
+      anon_sym_LT_SLASH,
+    ACTIONS(109), 4,
+      sym_comment,
+      ts_builtin_sym_end,
+      sym_entity,
+      sym_text,
+  [621] = 2,
+    ACTIONS(85), 3,
+      anon_sym_LT_BANG,
+      anon_sym_LT,
+      anon_sym_LT_SLASH,
+    ACTIONS(87), 4,
+      sym_comment,
+      ts_builtin_sym_end,
+      sym_entity,
+      sym_text,
+  [633] = 5,
+    ACTIONS(135), 1,
+      sym_attribute_name,
+    ACTIONS(137), 1,
+      sym_attribute_value_fragment,
+    ACTIONS(139), 1,
+      sym_entity,
+    STATE(38), 1,
+      aux_sym_attribute_value_repeat1,
+    ACTIONS(133), 2,
       anon_sym_GT,
       anon_sym_SLASH_GT,
-    STATE(35), 2,
-      sym_attribute,
-      aux_sym_start_tag_repeat1,
-  [678] = 5,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(128), 1,
+  [650] = 5,
+    ACTIONS(143), 1,
+      sym_attribute_name,
+    ACTIONS(145), 1,
+      sym_attribute_value_fragment,
+    ACTIONS(148), 1,
+      sym_entity,
+    STATE(38), 1,
+      aux_sym_attribute_value_repeat1,
+    ACTIONS(141), 2,
       anon_sym_GT,
-    ACTIONS(130), 1,
       anon_sym_SLASH_GT,
-    ACTIONS(132), 1,
-      sym_attribute_name,
-    STATE(35), 2,
-      sym_attribute,
-      aux_sym_start_tag_repeat1,
-  [695] = 5,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(132), 1,
-      sym_attribute_name,
-    ACTIONS(134), 1,
+  [667] = 4,
+    ACTIONS(141), 1,
       anon_sym_GT,
-    ACTIONS(136), 1,
+    ACTIONS(143), 1,
+      sym_attribute_name,
+    STATE(39), 1,
+      aux_sym_attribute_value_repeat1,
+    ACTIONS(151), 2,
+      sym_attribute_value_fragment,
+      sym_entity,
+  [681] = 4,
+    ACTIONS(154), 1,
+      anon_sym_GT,
+    ACTIONS(156), 1,
       anon_sym_SLASH_GT,
-    STATE(38), 2,
+    ACTIONS(158), 1,
+      sym_attribute_name,
+    STATE(43), 2,
       sym_attribute,
       aux_sym_start_tag_repeat1,
-  [712] = 5,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(128), 1,
-      anon_sym_GT,
-    ACTIONS(132), 1,
+  [695] = 4,
+    ACTIONS(158), 1,
       sym_attribute_name,
-    ACTIONS(138), 1,
+    ACTIONS(160), 1,
+      anon_sym_GT,
+    ACTIONS(162), 1,
       anon_sym_SLASH_GT,
-    STATE(35), 2,
+    STATE(42), 2,
       sym_attribute,
       aux_sym_start_tag_repeat1,
-  [729] = 5,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(132), 1,
-      sym_attribute_name,
-    ACTIONS(134), 1,
+  [709] = 4,
+    ACTIONS(154), 1,
       anon_sym_GT,
-    ACTIONS(140), 1,
+    ACTIONS(158), 1,
+      sym_attribute_name,
+    ACTIONS(164), 1,
       anon_sym_SLASH_GT,
-    STATE(36), 2,
+    STATE(43), 2,
       sym_attribute,
       aux_sym_start_tag_repeat1,
-  [746] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(142), 1,
-      anon_sym_GT,
-    ACTIONS(144), 1,
+  [723] = 3,
+    ACTIONS(168), 1,
       sym_attribute_name,
-    STATE(41), 2,
+    ACTIONS(166), 2,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+    STATE(43), 2,
       sym_attribute,
       aux_sym_start_tag_repeat1,
-  [760] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(123), 1,
+  [735] = 4,
+    ACTIONS(133), 1,
       anon_sym_GT,
-    ACTIONS(146), 1,
+    ACTIONS(135), 1,
       sym_attribute_name,
-    STATE(41), 2,
-      sym_attribute,
-      aux_sym_start_tag_repeat1,
-  [774] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(144), 1,
+    STATE(39), 1,
+      aux_sym_attribute_value_repeat1,
+    ACTIONS(171), 2,
+      sym_attribute_value_fragment,
+      sym_entity,
+  [749] = 4,
+    ACTIONS(158), 1,
       sym_attribute_name,
-    ACTIONS(149), 1,
+    ACTIONS(160), 1,
       anon_sym_GT,
+    ACTIONS(173), 1,
+      anon_sym_SLASH_GT,
     STATE(40), 2,
       sym_attribute,
       aux_sym_start_tag_repeat1,
-  [788] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(144), 1,
-      sym_attribute_name,
-    ACTIONS(151), 1,
+  [763] = 3,
+    ACTIONS(175), 1,
       anon_sym_GT,
-    STATE(44), 2,
+    ACTIONS(177), 1,
+      sym_attribute_name,
+    STATE(55), 2,
       sym_attribute,
       aux_sym_start_tag_repeat1,
-  [802] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(144), 1,
-      sym_attribute_name,
-    ACTIONS(153), 1,
-      anon_sym_GT,
-    STATE(41), 2,
-      sym_attribute,
-      aux_sym_start_tag_repeat1,
-  [816] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(157), 1,
-      anon_sym_EQ,
-    ACTIONS(155), 3,
-      anon_sym_GT,
-      anon_sym_SLASH_GT,
-      sym_attribute_name,
-  [828] = 5,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(159), 1,
-      sym_attribute_value,
-    ACTIONS(161), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(163), 1,
-      anon_sym_DQUOTE,
-    STATE(56), 1,
-      sym_quoted_attribute_value,
-  [844] = 5,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(165), 1,
-      sym_attribute_value,
-    ACTIONS(167), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(169), 1,
-      anon_sym_DQUOTE,
-    STATE(58), 1,
-      sym_quoted_attribute_value,
-  [860] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(171), 1,
-      anon_sym_LT_SLASH,
-    ACTIONS(173), 1,
-      sym_raw_text,
-    STATE(19), 1,
-      sym_end_tag,
-  [873] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(175), 3,
-      anon_sym_GT,
-      anon_sym_SLASH_GT,
-      sym_attribute_name,
-  [882] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(177), 3,
-      anon_sym_GT,
-      anon_sym_SLASH_GT,
-      sym_attribute_name,
-  [891] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(179), 1,
-      anon_sym_EQ,
-    ACTIONS(155), 2,
-      anon_sym_GT,
-      sym_attribute_name,
-  [902] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
+  [774] = 3,
     ACTIONS(181), 1,
-      sym__start_tag_name,
-    ACTIONS(183), 1,
-      sym__script_start_tag_name,
+      anon_sym_SQUOTE,
+    STATE(58), 1,
+      aux_sym_quoted_attribute_value_repeat1,
+    ACTIONS(179), 2,
+      sym_entity,
+      sym_unescaped_single_attribute_value_fragment,
+  [785] = 3,
     ACTIONS(185), 1,
-      sym__style_start_tag_name,
-  [915] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(171), 1,
-      anon_sym_LT_SLASH,
-    ACTIONS(187), 1,
-      sym_raw_text,
-    STATE(10), 1,
-      sym_end_tag,
-  [928] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
+      anon_sym_SQUOTE,
+    STATE(52), 1,
+      aux_sym_quoted_attribute_value_repeat1,
+    ACTIONS(183), 2,
+      sym_entity,
+      sym_unescaped_single_attribute_value_fragment,
+  [796] = 3,
+    ACTIONS(185), 1,
+      anon_sym_DQUOTE,
+    STATE(53), 1,
+      aux_sym_quoted_attribute_value_repeat2,
+    ACTIONS(187), 2,
+      sym_entity,
+      sym_unescaped_double_attribute_value_fragment,
+  [807] = 3,
+    ACTIONS(177), 1,
+      sym_attribute_name,
     ACTIONS(189), 1,
-      anon_sym_LT_SLASH,
+      anon_sym_GT,
+    STATE(51), 2,
+      sym_attribute,
+      aux_sym_start_tag_repeat1,
+  [818] = 3,
+    ACTIONS(177), 1,
+      sym_attribute_name,
     ACTIONS(191), 1,
+      anon_sym_GT,
+    STATE(55), 2,
+      sym_attribute,
+      aux_sym_start_tag_repeat1,
+  [829] = 3,
+    ACTIONS(195), 1,
+      anon_sym_SQUOTE,
+    STATE(56), 1,
+      aux_sym_quoted_attribute_value_repeat1,
+    ACTIONS(193), 2,
+      sym_entity,
+      sym_unescaped_single_attribute_value_fragment,
+  [840] = 3,
+    ACTIONS(195), 1,
+      anon_sym_DQUOTE,
+    STATE(57), 1,
+      aux_sym_quoted_attribute_value_repeat2,
+    ACTIONS(197), 2,
+      sym_entity,
+      sym_unescaped_double_attribute_value_fragment,
+  [851] = 3,
+    ACTIONS(181), 1,
+      anon_sym_DQUOTE,
+    STATE(60), 1,
+      aux_sym_quoted_attribute_value_repeat2,
+    ACTIONS(199), 2,
+      sym_entity,
+      sym_unescaped_double_attribute_value_fragment,
+  [862] = 3,
+    ACTIONS(166), 1,
+      anon_sym_GT,
+    ACTIONS(201), 1,
+      sym_attribute_name,
+    STATE(55), 2,
+      sym_attribute,
+      aux_sym_start_tag_repeat1,
+  [873] = 3,
+    ACTIONS(207), 1,
+      anon_sym_SQUOTE,
+    STATE(56), 1,
+      aux_sym_quoted_attribute_value_repeat1,
+    ACTIONS(204), 2,
+      sym_entity,
+      sym_unescaped_single_attribute_value_fragment,
+  [884] = 3,
+    ACTIONS(212), 1,
+      anon_sym_DQUOTE,
+    STATE(57), 1,
+      aux_sym_quoted_attribute_value_repeat2,
+    ACTIONS(209), 2,
+      sym_entity,
+      sym_unescaped_double_attribute_value_fragment,
+  [895] = 3,
+    ACTIONS(214), 1,
+      anon_sym_SQUOTE,
+    STATE(56), 1,
+      aux_sym_quoted_attribute_value_repeat1,
+    ACTIONS(193), 2,
+      sym_entity,
+      sym_unescaped_single_attribute_value_fragment,
+  [906] = 2,
+    ACTIONS(218), 1,
+      anon_sym_EQ,
+    ACTIONS(216), 3,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+      sym_attribute_name,
+  [915] = 3,
+    ACTIONS(214), 1,
+      anon_sym_DQUOTE,
+    STATE(57), 1,
+      aux_sym_quoted_attribute_value_repeat2,
+    ACTIONS(197), 2,
+      sym_entity,
+      sym_unescaped_double_attribute_value_fragment,
+  [926] = 3,
+    ACTIONS(177), 1,
+      sym_attribute_name,
+    ACTIONS(220), 1,
+      anon_sym_GT,
+    STATE(46), 2,
+      sym_attribute,
+      aux_sym_start_tag_repeat1,
+  [937] = 1,
+    ACTIONS(222), 3,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+      sym_attribute_name,
+  [943] = 1,
+    ACTIONS(224), 3,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+      sym_attribute_name,
+  [949] = 3,
+    ACTIONS(226), 1,
+      sym__start_tag_name,
+    ACTIONS(228), 1,
+      sym__script_start_tag_name,
+    ACTIONS(230), 1,
+      sym__style_start_tag_name,
+  [959] = 2,
+    ACTIONS(232), 1,
+      anon_sym_EQ,
+    ACTIONS(216), 2,
+      anon_sym_GT,
+      sym_attribute_name,
+  [967] = 3,
+    ACTIONS(228), 1,
+      sym__script_start_tag_name,
+    ACTIONS(230), 1,
+      sym__style_start_tag_name,
+    ACTIONS(234), 1,
+      sym__start_tag_name,
+  [977] = 1,
+    ACTIONS(236), 3,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+      sym_attribute_name,
+  [983] = 3,
+    ACTIONS(238), 1,
+      anon_sym_LT_SLASH,
+    ACTIONS(240), 1,
+      sym_raw_text,
+    STATE(20), 1,
+      sym_end_tag,
+  [993] = 3,
+    ACTIONS(238), 1,
+      anon_sym_LT_SLASH,
+    ACTIONS(242), 1,
+      sym_raw_text,
+    STATE(22), 1,
+      sym_end_tag,
+  [1003] = 3,
+    ACTIONS(244), 1,
+      anon_sym_LT_SLASH,
+    ACTIONS(246), 1,
+      sym_raw_text,
+    STATE(21), 1,
+      sym_end_tag,
+  [1013] = 3,
+    ACTIONS(244), 1,
+      anon_sym_LT_SLASH,
+    ACTIONS(248), 1,
       sym_raw_text,
     STATE(23), 1,
       sym_end_tag,
-  [941] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(189), 1,
-      anon_sym_LT_SLASH,
-    ACTIONS(193), 1,
+  [1023] = 1,
+    ACTIONS(250), 2,
       sym_raw_text,
-    STATE(24), 1,
+      anon_sym_LT_SLASH,
+  [1028] = 2,
+    ACTIONS(238), 1,
+      anon_sym_LT_SLASH,
+    STATE(13), 1,
       sym_end_tag,
-  [954] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(195), 3,
-      anon_sym_GT,
-      anon_sym_SLASH_GT,
-      sym_attribute_name,
-  [963] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(183), 1,
-      sym__script_start_tag_name,
-    ACTIONS(185), 1,
-      sym__style_start_tag_name,
-    ACTIONS(197), 1,
-      sym__start_tag_name,
-  [976] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(195), 2,
+  [1035] = 1,
+    ACTIONS(252), 2,
+      sym_raw_text,
+      anon_sym_LT_SLASH,
+  [1040] = 1,
+    ACTIONS(236), 2,
       anon_sym_GT,
       sym_attribute_name,
-  [984] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(199), 1,
+  [1045] = 2,
+    ACTIONS(254), 1,
       sym__end_tag_name,
-    ACTIONS(201), 1,
+    ACTIONS(256), 1,
       sym_erroneous_end_tag_name,
-  [994] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(171), 1,
-      anon_sym_LT_SLASH,
-    STATE(16), 1,
-      sym_end_tag,
-  [1004] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(203), 2,
-      sym_raw_text,
-      anon_sym_LT_SLASH,
-  [1012] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(205), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(207), 1,
-      aux_sym_quoted_attribute_value_token2,
-  [1022] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(175), 2,
+  [1052] = 1,
+    ACTIONS(222), 2,
       anon_sym_GT,
       sym_attribute_name,
-  [1030] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(177), 2,
-      anon_sym_GT,
-      sym_attribute_name,
-  [1038] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(209), 2,
-      sym_raw_text,
+  [1057] = 2,
+    ACTIONS(238), 1,
       anon_sym_LT_SLASH,
-  [1046] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(211), 2,
-      sym_raw_text,
-      anon_sym_LT_SLASH,
-  [1054] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(213), 2,
-      sym_raw_text,
-      anon_sym_LT_SLASH,
-  [1062] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(201), 1,
-      sym_erroneous_end_tag_name,
-    ACTIONS(215), 1,
-      sym__end_tag_name,
-  [1072] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(189), 1,
-      anon_sym_LT_SLASH,
-    STATE(28), 1,
+    STATE(12), 1,
       sym_end_tag,
-  [1082] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(189), 1,
+  [1064] = 2,
+    ACTIONS(244), 1,
       anon_sym_LT_SLASH,
     STATE(29), 1,
       sym_end_tag,
-  [1092] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(171), 1,
+  [1071] = 2,
+    ACTIONS(244), 1,
       anon_sym_LT_SLASH,
-    STATE(15), 1,
+    STATE(30), 1,
       sym_end_tag,
-  [1102] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(205), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(217), 1,
-      aux_sym_quoted_attribute_value_token1,
-  [1112] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(219), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(221), 1,
-      aux_sym_quoted_attribute_value_token1,
-  [1122] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(219), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(223), 1,
-      aux_sym_quoted_attribute_value_token2,
-  [1132] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(225), 1,
-      anon_sym_DQUOTE,
-  [1139] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(227), 1,
-      anon_sym_DQUOTE,
-  [1146] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(229), 1,
+  [1078] = 1,
+    ACTIONS(258), 2,
+      sym_raw_text,
+      anon_sym_LT_SLASH,
+  [1083] = 1,
+    ACTIONS(260), 2,
+      sym_raw_text,
+      anon_sym_LT_SLASH,
+  [1088] = 2,
+    ACTIONS(256), 1,
+      sym_erroneous_end_tag_name,
+    ACTIONS(262), 1,
+      sym__end_tag_name,
+  [1095] = 1,
+    ACTIONS(224), 2,
+      anon_sym_GT,
+      sym_attribute_name,
+  [1100] = 1,
+    ACTIONS(256), 1,
+      sym_erroneous_end_tag_name,
+  [1104] = 1,
+    ACTIONS(264), 1,
+      aux_sym_doctype_token1,
+  [1108] = 1,
+    ACTIONS(266), 1,
+      anon_sym_GT,
+  [1112] = 1,
+    ACTIONS(268), 1,
+      anon_sym_GT,
+  [1116] = 1,
+    ACTIONS(270), 1,
+      anon_sym_GT,
+  [1120] = 1,
+    ACTIONS(262), 1,
+      sym__end_tag_name,
+  [1124] = 1,
+    ACTIONS(272), 1,
       sym__doctype,
-  [1153] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(227), 1,
-      anon_sym_SQUOTE,
-  [1160] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(231), 1,
+  [1128] = 1,
+    ACTIONS(274), 1,
+      sym_erroneous_end_tag_name,
+  [1132] = 1,
+    ACTIONS(276), 1,
       anon_sym_GT,
-  [1167] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(233), 1,
+  [1136] = 1,
+    ACTIONS(278), 1,
       anon_sym_GT,
-  [1174] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(235), 1,
+  [1140] = 1,
+    ACTIONS(280), 1,
+      anon_sym_GT,
+  [1144] = 1,
+    ACTIONS(282), 1,
       aux_sym_doctype_token1,
-  [1181] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(237), 1,
-      anon_sym_GT,
-  [1188] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(239), 1,
+  [1148] = 1,
+    ACTIONS(284), 1,
       ts_builtin_sym_end,
-  [1195] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(241), 1,
-      anon_sym_GT,
-  [1202] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(243), 1,
-      sym_erroneous_end_tag_name,
-  [1209] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(225), 1,
-      anon_sym_SQUOTE,
-  [1216] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(245), 1,
-      anon_sym_GT,
-  [1223] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(215), 1,
+  [1152] = 1,
+    ACTIONS(254), 1,
       sym__end_tag_name,
-  [1230] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(201), 1,
-      sym_erroneous_end_tag_name,
-  [1237] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(247), 1,
-      aux_sym_doctype_token1,
-  [1244] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(249), 1,
-      anon_sym_GT,
-  [1251] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(199), 1,
-      sym__end_tag_name,
-  [1258] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(251), 1,
+  [1156] = 1,
+    ACTIONS(286), 1,
       sym__doctype,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(2)] = 0,
-  [SMALL_STATE(3)] = 44,
-  [SMALL_STATE(4)] = 88,
-  [SMALL_STATE(5)] = 132,
-  [SMALL_STATE(6)] = 176,
-  [SMALL_STATE(7)] = 217,
-  [SMALL_STATE(8)] = 258,
-  [SMALL_STATE(9)] = 299,
-  [SMALL_STATE(10)] = 313,
-  [SMALL_STATE(11)] = 327,
-  [SMALL_STATE(12)] = 341,
-  [SMALL_STATE(13)] = 355,
-  [SMALL_STATE(14)] = 369,
-  [SMALL_STATE(15)] = 383,
-  [SMALL_STATE(16)] = 397,
-  [SMALL_STATE(17)] = 411,
-  [SMALL_STATE(18)] = 425,
-  [SMALL_STATE(19)] = 439,
-  [SMALL_STATE(20)] = 453,
-  [SMALL_STATE(21)] = 467,
-  [SMALL_STATE(22)] = 481,
-  [SMALL_STATE(23)] = 495,
-  [SMALL_STATE(24)] = 509,
-  [SMALL_STATE(25)] = 523,
-  [SMALL_STATE(26)] = 537,
-  [SMALL_STATE(27)] = 551,
-  [SMALL_STATE(28)] = 565,
-  [SMALL_STATE(29)] = 579,
-  [SMALL_STATE(30)] = 593,
-  [SMALL_STATE(31)] = 607,
-  [SMALL_STATE(32)] = 621,
-  [SMALL_STATE(33)] = 635,
-  [SMALL_STATE(34)] = 649,
-  [SMALL_STATE(35)] = 663,
-  [SMALL_STATE(36)] = 678,
-  [SMALL_STATE(37)] = 695,
-  [SMALL_STATE(38)] = 712,
-  [SMALL_STATE(39)] = 729,
-  [SMALL_STATE(40)] = 746,
-  [SMALL_STATE(41)] = 760,
-  [SMALL_STATE(42)] = 774,
-  [SMALL_STATE(43)] = 788,
-  [SMALL_STATE(44)] = 802,
-  [SMALL_STATE(45)] = 816,
-  [SMALL_STATE(46)] = 828,
-  [SMALL_STATE(47)] = 844,
-  [SMALL_STATE(48)] = 860,
-  [SMALL_STATE(49)] = 873,
-  [SMALL_STATE(50)] = 882,
-  [SMALL_STATE(51)] = 891,
-  [SMALL_STATE(52)] = 902,
-  [SMALL_STATE(53)] = 915,
-  [SMALL_STATE(54)] = 928,
-  [SMALL_STATE(55)] = 941,
-  [SMALL_STATE(56)] = 954,
-  [SMALL_STATE(57)] = 963,
-  [SMALL_STATE(58)] = 976,
-  [SMALL_STATE(59)] = 984,
-  [SMALL_STATE(60)] = 994,
-  [SMALL_STATE(61)] = 1004,
-  [SMALL_STATE(62)] = 1012,
-  [SMALL_STATE(63)] = 1022,
-  [SMALL_STATE(64)] = 1030,
-  [SMALL_STATE(65)] = 1038,
-  [SMALL_STATE(66)] = 1046,
-  [SMALL_STATE(67)] = 1054,
-  [SMALL_STATE(68)] = 1062,
-  [SMALL_STATE(69)] = 1072,
-  [SMALL_STATE(70)] = 1082,
-  [SMALL_STATE(71)] = 1092,
-  [SMALL_STATE(72)] = 1102,
-  [SMALL_STATE(73)] = 1112,
-  [SMALL_STATE(74)] = 1122,
-  [SMALL_STATE(75)] = 1132,
-  [SMALL_STATE(76)] = 1139,
-  [SMALL_STATE(77)] = 1146,
-  [SMALL_STATE(78)] = 1153,
-  [SMALL_STATE(79)] = 1160,
-  [SMALL_STATE(80)] = 1167,
-  [SMALL_STATE(81)] = 1174,
-  [SMALL_STATE(82)] = 1181,
-  [SMALL_STATE(83)] = 1188,
-  [SMALL_STATE(84)] = 1195,
-  [SMALL_STATE(85)] = 1202,
-  [SMALL_STATE(86)] = 1209,
-  [SMALL_STATE(87)] = 1216,
-  [SMALL_STATE(88)] = 1223,
-  [SMALL_STATE(89)] = 1230,
-  [SMALL_STATE(90)] = 1237,
-  [SMALL_STATE(91)] = 1244,
-  [SMALL_STATE(92)] = 1251,
-  [SMALL_STATE(93)] = 1258,
+  [SMALL_STATE(3)] = 42,
+  [SMALL_STATE(4)] = 84,
+  [SMALL_STATE(5)] = 126,
+  [SMALL_STATE(6)] = 168,
+  [SMALL_STATE(7)] = 207,
+  [SMALL_STATE(8)] = 246,
+  [SMALL_STATE(9)] = 285,
+  [SMALL_STATE(10)] = 297,
+  [SMALL_STATE(11)] = 309,
+  [SMALL_STATE(12)] = 321,
+  [SMALL_STATE(13)] = 333,
+  [SMALL_STATE(14)] = 345,
+  [SMALL_STATE(15)] = 357,
+  [SMALL_STATE(16)] = 369,
+  [SMALL_STATE(17)] = 381,
+  [SMALL_STATE(18)] = 393,
+  [SMALL_STATE(19)] = 411,
+  [SMALL_STATE(20)] = 423,
+  [SMALL_STATE(21)] = 435,
+  [SMALL_STATE(22)] = 447,
+  [SMALL_STATE(23)] = 459,
+  [SMALL_STATE(24)] = 471,
+  [SMALL_STATE(25)] = 483,
+  [SMALL_STATE(26)] = 495,
+  [SMALL_STATE(27)] = 507,
+  [SMALL_STATE(28)] = 519,
+  [SMALL_STATE(29)] = 531,
+  [SMALL_STATE(30)] = 543,
+  [SMALL_STATE(31)] = 555,
+  [SMALL_STATE(32)] = 567,
+  [SMALL_STATE(33)] = 585,
+  [SMALL_STATE(34)] = 597,
+  [SMALL_STATE(35)] = 609,
+  [SMALL_STATE(36)] = 621,
+  [SMALL_STATE(37)] = 633,
+  [SMALL_STATE(38)] = 650,
+  [SMALL_STATE(39)] = 667,
+  [SMALL_STATE(40)] = 681,
+  [SMALL_STATE(41)] = 695,
+  [SMALL_STATE(42)] = 709,
+  [SMALL_STATE(43)] = 723,
+  [SMALL_STATE(44)] = 735,
+  [SMALL_STATE(45)] = 749,
+  [SMALL_STATE(46)] = 763,
+  [SMALL_STATE(47)] = 774,
+  [SMALL_STATE(48)] = 785,
+  [SMALL_STATE(49)] = 796,
+  [SMALL_STATE(50)] = 807,
+  [SMALL_STATE(51)] = 818,
+  [SMALL_STATE(52)] = 829,
+  [SMALL_STATE(53)] = 840,
+  [SMALL_STATE(54)] = 851,
+  [SMALL_STATE(55)] = 862,
+  [SMALL_STATE(56)] = 873,
+  [SMALL_STATE(57)] = 884,
+  [SMALL_STATE(58)] = 895,
+  [SMALL_STATE(59)] = 906,
+  [SMALL_STATE(60)] = 915,
+  [SMALL_STATE(61)] = 926,
+  [SMALL_STATE(62)] = 937,
+  [SMALL_STATE(63)] = 943,
+  [SMALL_STATE(64)] = 949,
+  [SMALL_STATE(65)] = 959,
+  [SMALL_STATE(66)] = 967,
+  [SMALL_STATE(67)] = 977,
+  [SMALL_STATE(68)] = 983,
+  [SMALL_STATE(69)] = 993,
+  [SMALL_STATE(70)] = 1003,
+  [SMALL_STATE(71)] = 1013,
+  [SMALL_STATE(72)] = 1023,
+  [SMALL_STATE(73)] = 1028,
+  [SMALL_STATE(74)] = 1035,
+  [SMALL_STATE(75)] = 1040,
+  [SMALL_STATE(76)] = 1045,
+  [SMALL_STATE(77)] = 1052,
+  [SMALL_STATE(78)] = 1057,
+  [SMALL_STATE(79)] = 1064,
+  [SMALL_STATE(80)] = 1071,
+  [SMALL_STATE(81)] = 1078,
+  [SMALL_STATE(82)] = 1083,
+  [SMALL_STATE(83)] = 1088,
+  [SMALL_STATE(84)] = 1095,
+  [SMALL_STATE(85)] = 1100,
+  [SMALL_STATE(86)] = 1104,
+  [SMALL_STATE(87)] = 1108,
+  [SMALL_STATE(88)] = 1112,
+  [SMALL_STATE(89)] = 1116,
+  [SMALL_STATE(90)] = 1120,
+  [SMALL_STATE(91)] = 1124,
+  [SMALL_STATE(92)] = 1128,
+  [SMALL_STATE(93)] = 1132,
+  [SMALL_STATE(94)] = 1136,
+  [SMALL_STATE(95)] = 1140,
+  [SMALL_STATE(96)] = 1144,
+  [SMALL_STATE(97)] = 1148,
+  [SMALL_STATE(98)] = 1152,
+  [SMALL_STATE(99)] = 1156,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
-  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
-  [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0, 0, 0),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(52),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(93),
-  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(57),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
-  [37] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(93),
-  [40] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(57),
-  [43] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(89),
-  [46] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(6),
-  [49] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
-  [51] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1, 0, 0),
-  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [55] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(77),
-  [58] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(52),
-  [61] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(85),
-  [64] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(8),
-  [67] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_end_tag, 3, 0, 0),
+  [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0, 0, 0),
+  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(91),
+  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(66),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(92),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(99),
+  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(64),
+  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(76),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [27] = {.entry = {.count = 1, .reusable = false}}, SHIFT(83),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [35] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1, 0, 0),
+  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [39] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
+  [41] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(91),
+  [44] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(66),
+  [47] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(92),
+  [50] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(7),
+  [53] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(99),
+  [56] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(64),
+  [59] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(85),
+  [62] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(8),
+  [65] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_element, 1, 0, 0),
+  [67] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_element, 1, 0, 0),
   [69] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_end_tag, 3, 0, 0),
-  [71] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_style_element, 2, 0, 0),
-  [73] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_style_element, 2, 0, 0),
-  [75] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_tag, 3, 0, 0),
-  [77] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_tag, 3, 0, 0),
-  [79] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_tag, 3, 0, 0),
-  [81] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_tag, 3, 0, 0),
-  [83] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_erroneous_end_tag, 3, 0, 0),
-  [85] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_erroneous_end_tag, 3, 0, 0),
+  [71] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_end_tag, 3, 0, 0),
+  [73] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctype, 4, 0, 0),
+  [75] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctype, 4, 0, 0),
+  [77] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_style_element, 3, 0, 0),
+  [79] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_style_element, 3, 0, 0),
+  [81] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_script_element, 3, 0, 0),
+  [83] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_script_element, 3, 0, 0),
+  [85] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_element, 3, 0, 0),
   [87] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_element, 3, 0, 0),
-  [89] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_element, 3, 0, 0),
-  [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_script_element, 3, 0, 0),
-  [93] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_script_element, 3, 0, 0),
-  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_style_element, 3, 0, 0),
-  [97] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_style_element, 3, 0, 0),
-  [99] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctype, 4, 0, 0),
-  [101] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctype, 4, 0, 0),
-  [103] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_tag, 4, 0, 0),
-  [105] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_tag, 4, 0, 0),
-  [107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_script_element, 2, 0, 0),
-  [109] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_script_element, 2, 0, 0),
-  [111] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_element, 1, 0, 0),
-  [113] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_element, 1, 0, 0),
-  [115] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_element, 2, 0, 0),
-  [117] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_element, 2, 0, 0),
-  [119] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_tag, 4, 0, 0),
-  [121] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_tag, 4, 0, 0),
-  [123] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2, 0, 0),
-  [125] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2, 0, 0), SHIFT_REPEAT(45),
-  [128] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [130] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [132] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
-  [134] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
-  [136] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
-  [138] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [140] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [142] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
-  [144] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
-  [146] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2, 0, 0), SHIFT_REPEAT(51),
-  [149] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
-  [151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
-  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
-  [155] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute, 1, 0, 0),
-  [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
-  [159] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
-  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
-  [165] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [167] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
-  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
-  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
-  [173] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
-  [175] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quoted_attribute_value, 2, 0, 0),
-  [177] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quoted_attribute_value, 3, 0, 0),
-  [179] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [181] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
-  [183] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [185] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
-  [187] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
-  [189] = {.entry = {.count = 1, .reusable = true}}, SHIFT(92),
-  [191] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
-  [193] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
-  [195] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute, 3, 0, 0),
-  [197] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [199] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
-  [201] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
-  [203] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_script_start_tag, 3, 0, 0),
-  [205] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
-  [207] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
-  [209] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_script_start_tag, 4, 0, 0),
-  [211] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_style_start_tag, 3, 0, 0),
-  [213] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_style_start_tag, 4, 0, 0),
-  [215] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
-  [217] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
-  [219] = {.entry = {.count = 1, .reusable = false}}, SHIFT(63),
-  [221] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
-  [223] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
-  [225] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
-  [227] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
-  [229] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
-  [231] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [233] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
-  [235] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
-  [237] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [239] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [241] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [243] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
-  [245] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [247] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
-  [249] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [251] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
+  [89] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_erroneous_end_tag, 3, 0, 0),
+  [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_erroneous_end_tag, 3, 0, 0),
+  [93] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_element, 2, 0, 0),
+  [95] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_element, 2, 0, 0),
+  [97] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_tag, 3, 0, 0),
+  [99] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_tag, 3, 0, 0),
+  [101] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [103] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [105] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [107] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_tag, 4, 0, 0),
+  [109] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_tag, 4, 0, 0),
+  [111] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_style_element, 2, 0, 0),
+  [113] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_style_element, 2, 0, 0),
+  [115] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_script_element, 2, 0, 0),
+  [117] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_script_element, 2, 0, 0),
+  [119] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_tag, 3, 0, 0),
+  [121] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_tag, 3, 0, 0),
+  [123] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [125] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [127] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [129] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_tag, 4, 0, 0),
+  [131] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_tag, 4, 0, 0),
+  [133] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute_value, 1, 0, 0),
+  [135] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_attribute_value, 1, 0, 0),
+  [137] = {.entry = {.count = 1, .reusable = false}}, SHIFT(38),
+  [139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [141] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_attribute_value_repeat1, 2, 0, 0),
+  [143] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_attribute_value_repeat1, 2, 0, 0),
+  [145] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_attribute_value_repeat1, 2, 0, 0), SHIFT_REPEAT(38),
+  [148] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_attribute_value_repeat1, 2, 0, 0), SHIFT_REPEAT(38),
+  [151] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_attribute_value_repeat1, 2, 0, 0), SHIFT_REPEAT(39),
+  [154] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [158] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [164] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [166] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2, 0, 0),
+  [168] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2, 0, 0), SHIFT_REPEAT(59),
+  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [173] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [175] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
+  [177] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [179] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
+  [181] = {.entry = {.count = 1, .reusable = false}}, SHIFT(75),
+  [183] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [185] = {.entry = {.count = 1, .reusable = false}}, SHIFT(67),
+  [187] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [189] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
+  [191] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
+  [193] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [195] = {.entry = {.count = 1, .reusable = false}}, SHIFT(62),
+  [197] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [199] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
+  [201] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2, 0, 0), SHIFT_REPEAT(65),
+  [204] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_quoted_attribute_value_repeat1, 2, 0, 0), SHIFT_REPEAT(56),
+  [207] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_quoted_attribute_value_repeat1, 2, 0, 0),
+  [209] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_quoted_attribute_value_repeat2, 2, 0, 0), SHIFT_REPEAT(57),
+  [212] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_quoted_attribute_value_repeat2, 2, 0, 0),
+  [214] = {.entry = {.count = 1, .reusable = false}}, SHIFT(77),
+  [216] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute, 1, 0, 0),
+  [218] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [220] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
+  [222] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quoted_attribute_value, 3, 0, 0),
+  [224] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute, 3, 0, 0),
+  [226] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [228] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
+  [230] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [232] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [234] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [236] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quoted_attribute_value, 2, 0, 0),
+  [238] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
+  [240] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
+  [242] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
+  [244] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
+  [246] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
+  [248] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
+  [250] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_script_start_tag, 4, 0, 0),
+  [252] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_style_start_tag, 3, 0, 0),
+  [254] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
+  [256] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
+  [258] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_script_start_tag, 3, 0, 0),
+  [260] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_style_start_tag, 4, 0, 0),
+  [262] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
+  [264] = {.entry = {.count = 1, .reusable = true}}, SHIFT(93),
+  [266] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [268] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [270] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [272] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
+  [274] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
+  [276] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [278] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [280] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [282] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
+  [284] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [286] = {.entry = {.count = 1, .reusable = true}}, SHIFT(96),
 };
 
 enum ts_external_scanner_symbol_identifiers {
@@ -2215,30 +2388,24 @@ static const bool ts_external_scanner_states[10][EXTERNAL_TOKEN_COUNT] = {
   },
   [4] = {
     [ts_external_token_SLASH_GT] = true,
-    [ts_external_token_comment] = true,
   },
   [5] = {
-    [ts_external_token_raw_text] = true,
-    [ts_external_token_comment] = true,
-  },
-  [6] = {
     [ts_external_token__start_tag_name] = true,
     [ts_external_token__script_start_tag_name] = true,
     [ts_external_token__style_start_tag_name] = true,
-    [ts_external_token_comment] = true,
+  },
+  [6] = {
+    [ts_external_token_raw_text] = true,
   },
   [7] = {
     [ts_external_token__end_tag_name] = true,
     [ts_external_token_erroneous_end_tag_name] = true,
-    [ts_external_token_comment] = true,
   },
   [8] = {
     [ts_external_token_erroneous_end_tag_name] = true,
-    [ts_external_token_comment] = true,
   },
   [9] = {
     [ts_external_token__end_tag_name] = true,
-    [ts_external_token_comment] = true,
   },
 };
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -300,7 +300,7 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
             lexer->mark_end(lexer);
             advance(lexer);
 
-            if (lexer->lookahead == '!') {
+            if (valid_symbols[COMMENT] && lexer->lookahead == '!') {
                 advance(lexer);
                 return scan_comment(lexer);
             }

--- a/test/corpus/main.txt
+++ b/test/corpus/main.txt
@@ -22,10 +22,11 @@ Tags with attributes
       (tag_name)
       (attribute
         (attribute_name)
-        (attribute_value))
+        (attribute_value
+          (attribute_value_fragment)))
       (attribute
         (attribute_name)
-        (quoted_attribute_value (attribute_value)))
+        (quoted_attribute_value (attribute_value_fragment)))
       (attribute
         (attribute_name)))
     (end_tag (tag_name))))
@@ -45,6 +46,7 @@ Nested tags
 (document
   (element
     (start_tag (tag_name))
+    (text)
     (element
       (start_tag (tag_name))
       (text)
@@ -69,13 +71,19 @@ Void tags
     (element
       (start_tag
         (tag_name)
-        (attribute (attribute_name) (quoted_attribute_value (attribute_value)))))
+        (attribute (attribute_name) (quoted_attribute_value (attribute_value_fragment)))))
     (element (start_tag (tag_name)))
     (element
       (self_closing_tag
         (tag_name)
-        (attribute (attribute_name) (attribute_value))
-        (attribute (attribute_name) (attribute_value))))
+        (attribute
+          (attribute_name)
+          (attribute_value
+            (attribute_value_fragment)))
+        (attribute
+          (attribute_name)
+          (attribute_value
+            (attribute_value_fragment)))))
     (end_tag (tag_name))))
 
 ==================================
@@ -88,7 +96,7 @@ Void tags at EOF
   (element
     (start_tag
       (tag_name)
-      (attribute (attribute_name) (quoted_attribute_value (attribute_value))))))
+      (attribute (attribute_name) (quoted_attribute_value (attribute_value_fragment))))))
 
 ==================================
 Custom tags
@@ -103,10 +111,12 @@ Custom tags
 (document
   (element
     (start_tag (tag_name))
+    (text)
     (element
       (start_tag (tag_name) (attribute (attribute_name)))
       (text)
       (end_tag (tag_name)))
+    (text)
     (end_tag (tag_name))))
 
 ==================================
@@ -122,9 +132,11 @@ Comments
 (document
   (comment)
   (comment)
+  (text)
   (element
     (start_tag (tag_name))
     (comment)
+    (text)
     (end_tag (tag_name))))
 
 ==================================
@@ -144,7 +156,6 @@ Raw text elements
 
 <script>
 </SCRIPT>
-
 ---
 
 (document
@@ -152,10 +163,12 @@ Raw text elements
     (start_tag (tag_name))
     (raw_text)
     (end_tag (tag_name)))
+  (text)
   (style_element
     (start_tag (tag_name))
     (raw_text)
     (end_tag (tag_name)))
+  (text)
   (script_element
     (start_tag (tag_name))
     (raw_text)
@@ -193,6 +206,7 @@ LI elements without close tags
 (document
   (element
     (start_tag (tag_name))
+    (text)
     (element (start_tag (tag_name)) (text))
     (element (start_tag (tag_name)) (text))
     (end_tag (tag_name))))
@@ -212,6 +226,7 @@ DT and DL elements without close tags
 (document
   (element
     (start_tag (tag_name))
+    (text)
     (element (start_tag (tag_name)) (text))
     (element (start_tag (tag_name)) (text))
     (element (start_tag (tag_name)) (text))
@@ -232,6 +247,7 @@ P elements without close tags
 (document
   (element (start_tag (tag_name)) (text))
   (element (start_tag (tag_name)) (text) (end_tag (tag_name)))
+  (text)
   (element (start_tag (tag_name)) (text))
   (element (start_tag (tag_name)) (text))
   (element (start_tag (tag_name)) (text) (end_tag (tag_name))))
@@ -269,20 +285,27 @@ COLGROUP elements without end tags
 (document
   (element
     (start_tag (tag_name))
+    (text)
     (element
       (start_tag (tag_name))
+      (text)
       (element (start_tag
         (tag_name)
-        (attribute (attribute_name) (quoted_attribute_value (attribute_value)))))
+        (attribute (attribute_name) (quoted_attribute_value (attribute_value_fragment)))))
       (element (start_tag
         (tag_name)
-        (attribute (attribute_name) (quoted_attribute_value (attribute_value))))))
+        (attribute (attribute_name) (quoted_attribute_value (attribute_value_fragment))))))
     (element
       (start_tag (tag_name))
+      (text)
       (element (start_tag (tag_name)) (text) (end_tag (tag_name)))
+      (text)
       (element (start_tag (tag_name)) (text) (end_tag (tag_name)))
+      (text)
       (element (start_tag (tag_name)) (text) (end_tag (tag_name)))
+      (text)
       (end_tag (tag_name)))
+    (text)
     (end_tag (tag_name))))
 
 =========================================
@@ -301,12 +324,15 @@ TR, TD, and TH elements without end tags
 (document
   (element
     (start_tag (tag_name))
+    (text)
     (element
       (start_tag (tag_name))
+      (text)
       (element (start_tag (tag_name)) (text))
       (element (start_tag (tag_name)) (text)))
     (element
       (start_tag (tag_name))
+      (text)
       (element (start_tag (tag_name)) (text))
       (element (start_tag (tag_name)) (text)))
     (end_tag (tag_name))))
@@ -314,7 +340,6 @@ TR, TD, and TH elements without end tags
 ==============================
 Named entities in tag contents
 ==============================
-
 <p>Lorem ipsum &nbsp; dolor sit &copy; amet.</p>
 ---
 
@@ -331,7 +356,6 @@ Named entities in tag contents
 ================================
 Numeric entities in tag contents
 ================================
-
 <p>Lorem ipsum &#160; dolor sit &#8212; amet.</p>
 ---
 
@@ -348,7 +372,6 @@ Numeric entities in tag contents
 =================================
 Multiple entities in tag contents
 =================================
-
 <p>Lorem ipsum &#xA0; dolor &#xa0; sit &nbsp; amet.</p>
 ---
 
@@ -367,9 +390,7 @@ Multiple entities in tag contents
 ==================================
 Omitted end tags for html and head
 ==================================
-
 <!doctype html><html><head>
-
 ---
 
 (document
@@ -380,3 +401,70 @@ Omitted end tags for html and head
     (element
       (start_tag
         (tag_name)))))
+
+
+==================================
+Fake comments in attribute values
+==================================
+<div title="<!-- Not a comment --> a <!-- Not a comment -->"/>
+<div title='<!-- Not a comment --> <!-- Not a comment -->'/>
+---
+
+(document
+  (element
+    (self_closing_tag
+      (tag_name)
+      (attribute
+        (attribute_name)
+        (quoted_attribute_value
+          (attribute_value_fragment)))))
+  (text)
+  (element
+    (self_closing_tag
+      (tag_name)
+      (attribute
+        (attribute_name)
+        (quoted_attribute_value
+          (attribute_value_fragment))))))
+
+==================================
+Entities in attribute values
+==================================
+<div title="&copy; &nbsp;&amp;"/>
+<div title='&copy; &nbsp;&amp;'/>
+<div title=&copy;&nbsp;_&amp;/>
+---
+
+(document
+  (element
+    (self_closing_tag
+      (tag_name)
+      (attribute
+        (attribute_name)
+        (quoted_attribute_value
+          (entity)
+          (attribute_value_fragment)
+          (entity)
+          (entity)))))
+  (text)
+  (element
+    (self_closing_tag
+      (tag_name)
+      (attribute
+        (attribute_name)
+        (quoted_attribute_value
+          (entity)
+          (attribute_value_fragment)
+          (entity)
+          (entity)))))
+  (text)
+  (element
+    (self_closing_tag
+      (tag_name)
+      (attribute
+        (attribute_name)
+        (attribute_value
+          (entity)
+          (entity)
+          (attribute_value_fragment)
+          (entity))))))

--- a/test/highlight/attributes.html
+++ b/test/highlight/attributes.html
@@ -15,20 +15,19 @@
   <!--                             ^^^ tag -->
   <div onclick="tap">Hello, World</div>
   <!--                                ^ punctuation.bracket -->
-  <something:different
+  <something:different @click="count++" :value="count">
   <!-- <- punctuation.bracket -->
   <!-- ^^^^^^^^^^^^^^^ tag -->
-    @click="count++"
-<!--^^^^^^^ attribute -->
-<!--        ^^^^^^^ string -->
-    :value="count"
-<!--^^^^^^^ attribute -->
-<!--        ^^^^^ string -->
-    @value:modelValue="newValue => count = newValue"
-<!--^^^^^^^^^^^^^^^^^^ attribute -->
-<!--                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string -->
-  >
-  <!-- <- punctuation.bracket -->
+  <!--                 ^^^^^^^ attribute -->
+  <!--                         ^^^^^^^ string -->
+  <!--                                  ^^^^^^^ attribute -->
+  <!--                                          ^^^^^ string -->
+  <!--                                                ^ punctuation.bracket -->
+
+    <div @value:modelValue="newValue => count = newValue"></div>
+    <!-- ^^^^^^^^^^^^^^^^^^ attribute -->
+    <!--                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string -->
+
   </something:different>
   <!-- <- punctuation.bracket -->
   <!-- ^^^^^^^^^^^^^^^^ tag -->

--- a/test/highlight/comments.html
+++ b/test/highlight/comments.html
@@ -1,0 +1,8 @@
+      <!-- comment -->
+<!--  ^^^^^^^^^^^^^^^^ comment -->
+
+<div title="<!-- Not a comment -->" />
+<!--        ^^^^^^^^^^^^^^^^^^^^^^ string -->
+
+<div title='<!-- Not a comment -->' />
+<!--        ^^^^^^^^^^^^^^^^^^^^^^ string -->

--- a/test/highlight/entity.html
+++ b/test/highlight/entity.html
@@ -1,0 +1,14 @@
+Test &amp;
+<!-- ^^^^^ entity -->
+
+<div title="test&amp;"></div>
+<!--            ^^^^^ entity -->
+<!--        ^^^^ string -->
+
+<div title='test&amp;'></div>
+<!--            ^^^^^ entity -->
+<!--        ^^^^ string -->
+
+<div title=test&amp;></div>
+<!--           ^^^^^ entity -->
+<!--       ^^^^ string -->


### PR DESCRIPTION
fix #51 
also fix #87 #89 (because I added `token.immediate` to `entity` but could be reverted if needed by creating two `entity` I think)